### PR TITLE
Add null move pruning. + 64

### DIFF
--- a/Pedantic/Chess/Board.cs
+++ b/Pedantic/Chess/Board.cs
@@ -515,6 +515,11 @@ namespace Pedantic.Chess
             return board[(int)sq];
         }
 
+        public int PieceCount(Color sideToMove)
+        {
+            return (Units(sideToMove).AndNot(Pieces(sideToMove, Piece.Pawn))).PopCount;
+        }
+
         public ref ByColor<SquareIndex> KingIndex
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Pedantic/Chess/SearchItem.cs
+++ b/Pedantic/Chess/SearchItem.cs
@@ -6,12 +6,14 @@ namespace Pedantic.Chess
         public Move Move;
         public bool IsCheckingMove;
         public MovePair Killers;
+        public short Eval;
 
         public SearchItem()
         {
             Move = Move.NullMove;
             IsCheckingMove = false;
             Killers = new();
+            Eval = 0;
         }
     }
 }

--- a/Pedantic/Chess/UciOptions.cs
+++ b/Pedantic/Chess/UciOptions.cs
@@ -31,6 +31,9 @@ namespace Pedantic.Chess
         internal const string OPT_ONE_MOVE_MAX_DEPTH = "UCI_T_OneMoveMaxDepth";
         internal const string OPT_QS_RECAPTURE_DEPTH = "UCI_T_QS_RecaptureDepth";
         internal const string OPT_QS_PROMOTION_DEPTH = "UCI_T_QS_PromotionDepth";
+        internal const string OPT_NMP_MIN_DEPTH = "UCI_T_NMP_MinDepth";
+        internal const string OPT_NMP_BASE_DEDUCTION = "UCI_T_NMP_BaseDeduction";
+        internal const string OPT_NMP_INC_DIVISOR = "UCI_T_NMP_IncDivisor";
 
         static UciOptions()
         {
@@ -277,6 +280,36 @@ namespace Pedantic.Chess
             }
         }
 
+        public static int NmpMinDepth
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                UciOptionSpin opt = (UciOptionSpin)options[OPT_NMP_MIN_DEPTH];
+                return opt.CurrentValue;
+            }
+        }
+
+        public static int NmpBaseDeduction
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                UciOptionSpin opt = (UciOptionSpin)options[OPT_NMP_BASE_DEDUCTION];
+                return opt.CurrentValue;
+            }
+        }
+
+        public static int NmpIncDivisor
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                UciOptionSpin opt = (UciOptionSpin)options[OPT_NMP_INC_DIVISOR];
+                return opt.CurrentValue;
+            }
+        }
+
         public static void WriteLine()
         {
             foreach (var opt in Options)
@@ -380,7 +413,10 @@ namespace Pedantic.Chess
             new UciOptionSpin(OPT_ASP_MIN_DEPTH, 6, 1, 10),
             new UciOptionSpin(OPT_ONE_MOVE_MAX_DEPTH, 10, 1, 20),
             new UciOptionSpin(OPT_QS_RECAPTURE_DEPTH, 6, 4, 8),
-            new UciOptionSpin(OPT_QS_PROMOTION_DEPTH, 2, 0, 8)
+            new UciOptionSpin(OPT_QS_PROMOTION_DEPTH, 2, 0, 8),
+            new UciOptionSpin(OPT_NMP_MIN_DEPTH, 3, 3, 6),
+            new UciOptionSpin(OPT_NMP_BASE_DEDUCTION, 3, 1, 8),
+            new UciOptionSpin(OPT_NMP_INC_DIVISOR, 4, 2, 8)
         ];
     }
 }

--- a/Pedantic/Program.cs
+++ b/Pedantic/Program.cs
@@ -103,6 +103,7 @@ namespace Pedantic
         static void InitializeStaticData()
         {
             Board.Initialize();
+            BasicSearch.Initialize();
         }
 
         private static async Task RunUci()


### PR DESCRIPTION
Score of Pedantic Dev vs Pedantic Base: 261 - 169 - 78  [0.591] 508
...      Pedantic Dev playing White: 141 - 79 - 34  [0.622] 254
...      Pedantic Dev playing Black: 120 - 90 - 44  [0.559] 254
...      White vs Black: 231 - 199 - 78  [0.531] 508
Elo difference: 63.6 +/- 28.2, LOS: 100.0 %, DrawRatio: 15.4 %
SPRT: llr 2.95 (100.2%), lbound -2.94, ubound 2.94 - H1 was accepted