### PR TITLE
Reverse futility pruning. +8 Elo

### DIFF
--- a/Pedantic/Chess/BasicSearch.cs
+++ b/Pedantic/Chess/BasicSearch.cs
@@ -396,6 +396,12 @@ namespace Pedantic.Chess
                 evaluation = ssItem.Eval = eval.Compute(board);
                 if (!isPv)
                 {
+                    // static null move pruning (reverse futility pruning)
+                    if (depth <= UciOptions.RfpMaxDepth && evaluation >= beta + depth * UciOptions.RfpMargin)
+                    {
+                        return evaluation;
+                    }
+
                     // Null Move Pruning - Prune if current evaluation looks so good that we can see what happens
                     // if we just skip our move.
                     if (canNull && depth >= UciOptions.NmpMinDepth && evaluation >= beta && board.PieceCount(board.SideToMove) > 1)
@@ -417,7 +423,7 @@ namespace Pedantic.Chess
                             if (score >= beta)
                             {
                                 ttCache.Store(board.Hash, depth, ply, alpha, beta, score, Move.NullMove);
-                                return beta;
+                                return score;
                             }
                         }
                         ssItem.Eval = (short)evaluation;

--- a/Pedantic/Chess/UciOptions.cs
+++ b/Pedantic/Chess/UciOptions.cs
@@ -39,6 +39,8 @@ namespace Pedantic.Chess
         internal const string OPT_LMR_DEPTH_FACTOR = "UCI_T_LMR_DepthFactor";
         internal const string OPT_LMR_MOVE_FACTOR = "UCI_T_LMR_MoveFactor";
         internal const string OPT_LMR_SCALE_FACTOR = "UCI_T_LMR_ScaleFactor";
+        internal const string OPT_RFP_MAX_DEPTH = "UCI_T_RFP_MaxDepth";
+        internal const string OPT_RFP_MARGIN = "UCI_T_RFP_Margin";
 
         static UciOptions()
         {
@@ -337,9 +339,30 @@ namespace Pedantic.Chess
 
         public static int LmrScaleFactor
         {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
                 UciOptionSpin opt = (UciOptionSpin)options[OPT_LMR_SCALE_FACTOR];
+                return opt.CurrentValue;
+            }
+        }
+
+        public static int RfpMaxDepth
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                UciOptionSpin opt = (UciOptionSpin)options[OPT_RFP_MAX_DEPTH];
+                return opt.CurrentValue;
+            }
+        }
+
+        public static int RfpMargin
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                UciOptionSpin opt = (UciOptionSpin)options[OPT_RFP_MARGIN];
                 return opt.CurrentValue;
             }
         }
@@ -454,7 +477,9 @@ namespace Pedantic.Chess
             new UciOptionSpin(OPT_NMP_INC_DIVISOR, 4, 2, 8),
             new UciOptionSpin(OPT_LMR_DEPTH_FACTOR, 18, 10, 30),
             new UciOptionSpin(OPT_LMR_MOVE_FACTOR, 10, 5, 20),
-            new UciOptionSpin(OPT_LMR_SCALE_FACTOR, 20, 10, 30)
+            new UciOptionSpin(OPT_LMR_SCALE_FACTOR, 20, 10, 30),
+            new UciOptionSpin(OPT_RFP_MAX_DEPTH, 6, 4, 12),
+            new UciOptionSpin(OPT_RFP_MARGIN, 85, 25, 250)
         ];
     }
 }


### PR DESCRIPTION
Score of Pedantic Dev vs Pedantic Base: 2630 - 2474 - 1552  [0.512] 6656
...      Pedantic Dev playing White: 1409 - 1114 - 805  [0.544] 3328
...      Pedantic Dev playing Black: 1221 - 1360 - 747  [0.479] 3328
...      White vs Black: 2769 - 2335 - 1552  [0.533] 6656
Elo difference: 8.1 +/- 7.3, LOS: 98.6 %, DrawRatio: 23.3 %
SPRT: llr 2.98 (101.2%), lbound -2.94, ubound 2.94 - H1 was accepted
info string depth 12 time 16.4050 nodes 36648383 nps 2233976.4096