### PR TITLE
Add quiet history w/gravity. +90 Elo

### DIFF
--- a/Pedantic/Chess/Engine.cs
+++ b/Pedantic/Chess/Engine.cs
@@ -94,6 +94,7 @@ namespace Pedantic.Chess
         public static void ClearHashTable()
         {
             TtCache.Default.Clear();
+            threads.ClearEvalCache();
             GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, true);
         }
 

--- a/Pedantic/Chess/HCE/Weights.cs
+++ b/Pedantic/Chess/HCE/Weights.cs
@@ -6,7 +6,7 @@ using Pedantic.Utilities;
 namespace Pedantic.Chess.HCE
 {
     // Coefficients or weights for the HCE evaluation function
-    public sealed class Weights
+    public sealed class Weights : IInitialize
     {
         #region Feature Identifiers/Constants
 
@@ -133,6 +133,8 @@ namespace Pedantic.Chess.HCE
         }
 
         #endregion
+
+        public static void Initialize() {}
 
         private static Score S(short mgValue, short egValue) => new Score(mgValue, egValue);
         private readonly Score[] weights = new Score[MAX_WEIGHTS];

--- a/Pedantic/Chess/History.cs
+++ b/Pedantic/Chess/History.cs
@@ -1,0 +1,90 @@
+﻿using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+using Pedantic.Collections;
+
+namespace Pedantic.Chess
+{
+    public unsafe sealed class History : IHistory
+    {
+        internal const nuint MEM_ALIGNMENT = 64;
+        internal const nuint HISTORY_LEN = MAX_COLORS * MAX_PIECES * MAX_SQUARES;
+        internal const short BONUS_MAX = 920;
+        internal const short BONUS_COEFF = 96;
+
+        private short[] history;
+        private SearchStack ss;
+        private int ply;
+
+        public History(SearchStack searchStack)
+        {
+            history = new short[HISTORY_LEN];
+            ss = searchStack;
+            ply = 0;
+        }
+
+        public short this[Color stm, Piece piece, SquareIndex sq]
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                return history[GetIndex(stm, piece, sq)];
+            }
+        }
+
+        public short this[Move move]
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                return history[GetIndex(move)];
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Clear()
+        {
+            Span<short> h = history;
+            h.Clear();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void SetContext(int ply)
+        {
+            this.ply = ply;
+        }
+
+        public void UpdateCutoff(Move move, int ply, ref StackList<Move> quiets, int depth)
+        {
+            SetContext(ply);
+            short bonus = Math.Min(BONUS_MAX, (short)(BONUS_COEFF * (depth - 1)));
+            int index = GetIndex(move);
+            UpdateHistory(ref history[index], bonus);
+
+            short malus = (short)-bonus;
+            for (int n = 0; n < quiets.Count; n++)
+            {
+                index = GetIndex(quiets[n]);
+                UpdateHistory(ref history[index], malus);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int GetIndex(Color stm, Piece piece, SquareIndex to)
+        {
+            return ((int)stm * MAX_PIECES + (int)piece) * MAX_SQUARES + (int) to;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int GetIndex(Move move)
+        {
+            return GetIndex(move.Stm, move.Piece, move.To);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void UpdateHistory(ref short hist, short bonus)
+        {
+            hist += (short)(bonus - hist * Math.Abs(bonus) / HISTORY_SCORE_MAX);
+        }
+    }
+}

--- a/Pedantic/Chess/MoveList.cs
+++ b/Pedantic/Chess/MoveList.cs
@@ -133,7 +133,7 @@ namespace Pedantic.Chess
         {
             Util.Assert(insertIndex < CAPACITY);
             Move move = new(stm, piece, from, to, type);
-            array[insertIndex++] = new ScoredMove { Move = move, Score = history[move] };
+            array[insertIndex++] = new ScoredMove { Move = move, Score = history[stm, piece, to] };
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Pedantic/Chess/SearchThread.cs
+++ b/Pedantic/Chess/SearchThread.cs
@@ -11,7 +11,8 @@ namespace Pedantic.Chess
             this.isPrimary = isPrimary;
             search = null;
             clock = null;
-            listPool = new(() => new MoveList(), (o) => o.Clear(), MAX_PLY, 32);
+            history = new(stack);
+            listPool = new(() => new MoveList(history), (o) => o.Clear(), MAX_PLY, 32);
         }
 
         public void Search(GameClock clock, Board board, int maxDepth, long maxNodes, CountdownEvent done)
@@ -21,7 +22,7 @@ namespace Pedantic.Chess
             this.clock = clock;
             eval.Update(board);
 
-            search = new(stack, board, clock, eval, listPool, TtCache.Default, maxDepth, maxNodes)
+            search = new(stack, board, clock, eval, history, listPool, TtCache.Default, maxDepth, maxNodes)
             {
                 CanPonder = UciOptions.Ponder,
                 Uci = uci
@@ -51,6 +52,7 @@ namespace Pedantic.Chess
         public double TotalTime => (search?.Elapsed ?? 0) / 1000.0;
         public bool IsPrimary => isPrimary;
         public SearchStack Stack => stack;
+        public History History => history;
         public ObjectPool<MoveList> MoveListPool => listPool;
 
         private readonly bool isPrimary;
@@ -58,6 +60,7 @@ namespace Pedantic.Chess
         private GameClock? clock;
         private readonly HceEval eval = new();
         private readonly SearchStack stack = new();
+        private readonly History history;
         private readonly ObjectPool<MoveList> listPool;
     }
 }

--- a/Pedantic/Chess/SearchThreads.cs
+++ b/Pedantic/Chess/SearchThreads.cs
@@ -39,6 +39,14 @@ namespace Pedantic.Chess
             }
         }
 
+        public void ClearEvalCache()
+        {
+            foreach (var thread in threads)
+            {
+                thread.History.Clear();
+            }
+        }
+
         public void Wait()
         {
             // wait (i.e. block) for search to be complete

--- a/Pedantic/Program.cs
+++ b/Pedantic/Program.cs
@@ -102,6 +102,7 @@ namespace Pedantic
 
         static void InitializeStaticData()
         {
+            Chess.HCE.Weights.Initialize();
             Board.Initialize();
             BasicSearch.Initialize();
         }


### PR DESCRIPTION
Score of Pedantic Dev vs Pedantic Base: 181 - 95 - 62  [0.627] 338
...      Pedantic Dev playing White: 97 - 46 - 27  [0.650] 170
...      Pedantic Dev playing Black: 84 - 49 - 35  [0.604] 168
...      White vs Black: 146 - 130 - 62  [0.524] 338
Elo difference: 90.4 +/- 34.4, LOS: 100.0 %, DrawRatio: 18.3 %
SPRT: llr 2.94 (100.0%), lbound -2.94, ubound 2.94 - H1 was accepted
info string depth 12 time 14.7040 nodes 33253088 nps 2261499.4559