### PR TITLE
Add pawn structure hash table. +18 Elo

### DIFF
--- a/Pedantic.UnitTests/EvaluationTests.cs
+++ b/Pedantic.UnitTests/EvaluationTests.cs
@@ -20,7 +20,8 @@ namespace Pedantic.UnitTests
         public void ComputeTest()
         {
             Board board = new Board(Constants.FEN_START_POS);
-            HceEval eval = new(Weights.Default);
+            EvalCache cache = new();
+            HceEval eval = new(cache, Weights.Default);
             short result = eval.Compute(board);
             Assert.AreEqual(0, result);
 

--- a/Pedantic.UnitTests/HceEvalTests.cs
+++ b/Pedantic.UnitTests/HceEvalTests.cs
@@ -62,7 +62,8 @@ namespace Pedantic.UnitTests
             Board bd = new Board(fen);
             EvalFeatures features = new(bd);
             short expected = features.Compute(HceEval.Weights);
-            HceEval eval = new();
+            EvalCache cache = new();
+            HceEval eval = new(cache);
             short actual = eval.Compute(bd);
             Assert.AreEqual(expected, actual);
         }

--- a/Pedantic/Chess/Engine.cs
+++ b/Pedantic/Chess/Engine.cs
@@ -108,6 +108,7 @@ namespace Pedantic.Chess
         public static void ResizeHashTable()
         {
             TtCache.Default.Resize();
+            threads.ResizeEvalCache();
         }
 
         public static bool SetupPosition(ReadOnlySpan<char> fen)

--- a/Pedantic/Chess/EvalCache.cs
+++ b/Pedantic/Chess/EvalCache.cs
@@ -1,0 +1,122 @@
+﻿using Pedantic.Utilities;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics.X86;
+
+namespace Pedantic.Chess
+{
+    public unsafe sealed class EvalCache : IDisposable
+    {
+        public const int MB_SIZE = 1024 * 1024;
+        public const int DEFAULT_CACHE_SIZE = 4;
+        public const int PAWN_CACHE_ITEM_SIZE = 20;
+        public const int MEM_ALIGNMENT = 64;
+
+        [StructLayout(LayoutKind.Sequential, Pack=4)]
+        public struct PawnCacheItem
+        {
+            public PawnCacheItem(ulong hash, Bitboard passedPawns, Score eval)
+            {
+                this.hash = hash;
+                this.passedPawns = passedPawns;
+                this.eval = eval;
+            }
+
+            public readonly ulong Hash => hash;
+            public readonly Bitboard PassedPawns => passedPawns;
+            public readonly Score Eval => eval;
+
+            public static void SetValue(ref PawnCacheItem item, ulong hash, Bitboard passedPawns, Score eval)
+            {
+                item.hash = hash;
+                item.passedPawns = passedPawns;
+                item.eval = eval;
+            }
+
+            public unsafe static int Size
+            {
+                get
+                {
+                    return sizeof(PawnCacheItem);
+                }
+            }
+
+            private ulong hash;
+            private Bitboard passedPawns;
+            private Score eval;
+        }
+
+        public EvalCache(int sizeMb = DEFAULT_CACHE_SIZE)
+        {
+            Util.Assert(sizeof(PawnCacheItem) == PAWN_CACHE_ITEM_SIZE);
+            pPawnCache = null;
+            Resize(sizeMb);
+        }
+
+        ~EvalCache()
+        {
+            if (pPawnCache != null)
+            {
+                NativeMemory.AlignedFree(pPawnCache);
+                pPawnCache = null;
+            }
+        }
+
+        public bool ProbePawnCache(ulong hash, out PawnCacheItem item)
+        {
+            int index = (int)(hash % (uint)pawnSize);
+            item = pPawnCache[index];
+            return item.Hash == hash;
+        }
+
+        public void SavePawnEval(ulong hash, Bitboard passedPawns, Score eval)
+        {
+            int index = (int)(hash % (uint)pawnSize);
+            ref PawnCacheItem item = ref pPawnCache[index];
+            PawnCacheItem.SetValue(ref item, hash, passedPawns, eval);
+        }
+
+        public void Resize(int sizeMb)
+        {
+            CalcCacheSizes(sizeMb, out pawnSize);
+            byteCount = (nuint)(sizeMb * MB_SIZE);
+            pPawnCache = (PawnCacheItem*)NativeMemory.AlignedRealloc(pPawnCache, byteCount, MEM_ALIGNMENT);
+            Clear();
+        }
+
+        public void Clear()
+        {
+            NativeMemory.Clear(pPawnCache, byteCount);
+        }
+
+        public static void CalcCacheSizes(int sizeMb, out int pawnSize)
+        {
+            sizeMb = Math.Clamp(sizeMb, 1, 128);
+            pawnSize = sizeMb * MB_SIZE / PawnCacheItem.Size;
+        }
+
+        public void PrefetchPawnCache(ulong hash)
+        {
+            if (Sse.IsSupported)
+            {
+                int index = (int)(hash % (uint)pawnSize);
+                Sse.Prefetch0(pPawnCache + index);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (pPawnCache != null)
+            {
+                NativeMemory.AlignedFree(pPawnCache);
+                pPawnCache = null;
+            }
+            GC.SuppressFinalize(this);
+        }
+
+        public int PawnCacheSize => pawnSize;
+
+        private int pawnSize;
+        private PawnCacheItem* pPawnCache;
+        private nuint byteCount;
+    }
+}

--- a/Pedantic/Chess/SearchThread.cs
+++ b/Pedantic/Chess/SearchThread.cs
@@ -11,6 +11,7 @@ namespace Pedantic.Chess
             this.isPrimary = isPrimary;
             search = null;
             clock = null;
+            eval = new(cache);
             history = new(stack);
             listPool = new(() => new MoveList(history), (o) => o.Clear(), MAX_PLY, 32);
         }
@@ -51,13 +52,15 @@ namespace Pedantic.Chess
         public double TotalTime => (search?.Elapsed ?? 0) / 1000.0;
         public bool IsPrimary => isPrimary;
         public SearchStack Stack => stack;
+        public EvalCache EvalCache => cache;
         public History History => history;
         public ObjectPool<MoveList> MoveListPool => listPool;
 
         private readonly bool isPrimary;
         private BasicSearch? search;
         private GameClock? clock;
-        private readonly HceEval eval = new();
+        private readonly EvalCache cache = new();
+        private readonly HceEval eval;
         private readonly SearchStack stack = new();
         private readonly History history;
         private readonly ObjectPool<MoveList> listPool;

--- a/Pedantic/Chess/SearchThreads.cs
+++ b/Pedantic/Chess/SearchThreads.cs
@@ -43,7 +43,17 @@ namespace Pedantic.Chess
         {
             foreach (var thread in threads)
             {
+                thread.EvalCache.Clear();
                 thread.History.Clear();
+            }
+        }
+
+        public void ResizeEvalCache()
+        {
+            int sizeMb = UciOptions.HashTableSize / 16;
+            foreach (var thread in threads)
+            {
+                thread.EvalCache.Resize(sizeMb);
             }
         }
 

--- a/Pedantic/Chess/TtCache.cs
+++ b/Pedantic/Chess/TtCache.cs
@@ -161,7 +161,7 @@ namespace Pedantic.Chess
             if (Sse.IsSupported)
             {
                 int index = (int)(hash & mask & 0xfffffffffffffffe);
-                Sse.Prefetch0((char*)pTable + index);
+                Sse.Prefetch0(pTable + index);
             }
         }
 

--- a/Pedantic/Properties/launchSettings.json
+++ b/Pedantic/Properties/launchSettings.json
@@ -10,6 +10,10 @@
     "Learn": {
       "commandName": "Project",
       "commandLineArgs": "learn --data \"e:/pgn files/training/master_training_data_ver7.0d.csv\" --sample 600000 --epochs 1000 --time 0:20:00 --reset"
+    },
+    "Search": {
+      "commandName": "Project",
+      "commandLineArgs": "< \"e:\\repos.2\\Pedantic\\uci_test.txt\""
     }
   }
 }

--- a/uci_test.txt
+++ b/uci_test.txt
@@ -1,0 +1,5 @@
+uci
+setoption name Hash value 128
+ucinewgame
+isready
+go


### PR DESCRIPTION
Score of Pedantic Dev vs Pedantic Base: 1137 - 990 - 766  [0.525] 2893
...      Pedantic Dev playing White: 615 - 450 - 381  [0.557] 1446
...      Pedantic Dev playing Black: 522 - 540 - 385  [0.494] 1447
...      White vs Black: 1155 - 972 - 766  [0.532] 2893
Elo difference: 17.7 +/- 10.9, LOS: 99.9 %, DrawRatio: 26.5 %
SPRT: llr 2.96 (100.6%), lbound -2.94, ubound 2.94 - H1 was accepted
info string depth 12 time 13.2370 nodes 25934133 nps 1959215.3056