### PR TITLE
Add late move pruning to search. +75 Elo

### DIFF
--- a/Pedantic/Chess/UciOptions.cs
+++ b/Pedantic/Chess/UciOptions.cs
@@ -41,6 +41,8 @@ namespace Pedantic.Chess
         internal const string OPT_LMR_SCALE_FACTOR = "UCI_T_LMR_ScaleFactor";
         internal const string OPT_RFP_MAX_DEPTH = "UCI_T_RFP_MaxDepth";
         internal const string OPT_RFP_MARGIN = "UCI_T_RFP_Margin";
+        internal const string OPT_LMP_MAX_DEPTH = "UCI_T_LMP_MaxDepth";
+        internal const string OPT_LMP_DEPTH_INCREMENT = "UCI_T_LMP_DepthIncrement";
 
         static UciOptions()
         {
@@ -367,6 +369,26 @@ namespace Pedantic.Chess
             }
         }
 
+        public static int LmpMaxDepth
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                UciOptionSpin opt = (UciOptionSpin)options[OPT_LMP_MAX_DEPTH];
+                return opt.CurrentValue;
+            }
+        }
+
+        public static int LmpDepthIncrement
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                UciOptionSpin opt = (UciOptionSpin)options[OPT_LMP_DEPTH_INCREMENT];
+                return opt.CurrentValue;
+            }
+        }
+
         public static void WriteLine()
         {
             foreach (var kvp in options)
@@ -479,7 +501,9 @@ namespace Pedantic.Chess
             new UciOptionSpin(OPT_LMR_MOVE_FACTOR, 10, 5, 20),
             new UciOptionSpin(OPT_LMR_SCALE_FACTOR, 20, 10, 30),
             new UciOptionSpin(OPT_RFP_MAX_DEPTH, 6, 4, 12),
-            new UciOptionSpin(OPT_RFP_MARGIN, 85, 25, 250)
+            new UciOptionSpin(OPT_RFP_MARGIN, 85, 25, 250),
+            new UciOptionSpin(OPT_LMP_MAX_DEPTH, 6, 1, 10),
+            new UciOptionSpin(OPT_LMP_DEPTH_INCREMENT, 1, 0, 5)
         ];
     }
 }


### PR DESCRIPTION
Score of Pedantic Dev vs Pedantic Base: 170 - 93 - 101  [0.606] 364
...      Pedantic Dev playing White: 93 - 46 - 44  [0.628] 183
...      Pedantic Dev playing Black: 77 - 47 - 57  [0.583] 181
...      White vs Black: 140 - 123 - 101  [0.523] 364
Elo difference: 74.6 +/- 30.8, LOS: 100.0 %, DrawRatio: 27.7 %
SPRT: llr 2.96 (100.5%), lbound -2.94, ubound 2.94 - H1 was accepted
info string depth 12 time 12.0260 nodes 19618616 nps 1631350.0748