### PR TITLE
Add counter move support to history. +10 elo

### DIFF
--- a/Pedantic.UnitTests/BoardTests.cs
+++ b/Pedantic.UnitTests/BoardTests.cs
@@ -225,8 +225,9 @@ namespace Pedantic.UnitTests
             Board board = new Board(fen);
             MoveList list = new();
             SearchStack ss = new();
+            History history = new(ss);
             int count = 0;
-            foreach (var mv in board.Moves(0, ss, list, Move.NullMove))
+            foreach (var mv in board.Moves(0, history, ss, list, Move.NullMove))
             {
                 TestContext?.WriteLine($"{mv.MovePhase}: {mv.Move.ToLongString()}");
                 ++count;

--- a/Pedantic.UnitTests/EvaluationTests.cs
+++ b/Pedantic.UnitTests/EvaluationTests.cs
@@ -23,11 +23,11 @@ namespace Pedantic.UnitTests
             EvalCache cache = new();
             HceEval eval = new(cache, Weights.Default);
             short result = eval.Compute(board);
-            Assert.AreEqual(0, result);
+            Assert.AreEqual(8, result);
 
             board.LoadFen("r3k2r/2pb1ppp/2pp1q2/p7/1nP1B3/1P2P3/P2N1PPP/R2QK2R w KQkq a6 0 14");
             result = eval.Compute(board);
-            Assert.AreEqual(0, result);
+            Assert.AreEqual(2, result);
         }
 
     }

--- a/Pedantic/Chess/BasicSearch.cs
+++ b/Pedantic/Chess/BasicSearch.cs
@@ -444,8 +444,8 @@ namespace Pedantic.Chess
             board.PushBoardState();
             MoveList list = listPool.Rent();
             IEnumerable<GenMove> moves = inCheck ?
-                board.Moves(ply, ss, list, ttMove) :
-                board.EvasionMoves(ply, ss, list, ttMove);
+                board.Moves(ply, history, ss, list, ttMove) :
+                board.EvasionMoves(ply, history, ss, list, ttMove);
             //IEnumerable<GenMove> moves = board.Moves(ply, ss, list, ttMove);
 
             foreach (GenMove genMove in moves)
@@ -601,7 +601,7 @@ namespace Pedantic.Chess
 
             IEnumerable<GenMove> moves = !inCheck ? 
                 board.QMoves(ply, qsPly, ss, list, ttMove) :
-                board.EvasionMoves(ply, ss, list, ttMove);
+                board.EvasionMoves(ply, history, ss, list, ttMove);
 
             foreach (GenMove genMove in moves)
             {

--- a/Pedantic/Chess/Board.cs
+++ b/Pedantic/Chess/Board.cs
@@ -988,7 +988,7 @@ namespace Pedantic.Chess
             return false;
         }
 
-        public IEnumerable<GenMove> Moves(int ply, SearchStack ss, MoveList list, Move ttMove)
+        public IEnumerable<GenMove> Moves(int ply, History history, SearchStack ss, MoveList list, Move ttMove)
         {
             if (ttMove != Move.NullMove)
             {
@@ -1029,6 +1029,12 @@ namespace Pedantic.Chess
             if (list.Remove(killer))
             {
                 yield return new GenMove(killer, MoveGenPhase.Killers);
+            }
+
+            Move counter = history.CounterMove(ss[ply - 1].Move);
+            if (list.Remove(counter))
+            {
+                yield return new GenMove(counter, MoveGenPhase.Counter);
             }
 
             for (int n = 0; n < list.Count; n++)
@@ -1074,7 +1080,7 @@ namespace Pedantic.Chess
             }
         }
 
-        public IEnumerable<GenMove> EvasionMoves(int ply, SearchStack ss, MoveList list, Move ttMove)
+        public IEnumerable<GenMove> EvasionMoves(int ply, History history, SearchStack ss, MoveList list, Move ttMove)
         {
             if (ttMove != Move.NullMove)
             {
@@ -1127,6 +1133,12 @@ namespace Pedantic.Chess
             if (list.Remove(killer))
             {
                 yield return new GenMove(killer, MoveGenPhase.Killers);
+            }
+
+            Move counter = history.CounterMove(ss[ply - 1].Move);
+            if (list.Remove(counter))
+            {
+                yield return new GenMove(counter, MoveGenPhase.Counter);
             }
 
             for (int n = 0; n < list.Count; n++)

--- a/Pedantic/Chess/Move.cs
+++ b/Pedantic/Chess/Move.cs
@@ -99,6 +99,20 @@ namespace Pedantic.Chess
             }
         }
 
+        public readonly bool IsValid
+        {
+            get
+            {
+                return  Stm >= Color.None && Stm <= Color.Black &&
+                        Piece >= Piece.None && Piece <= Piece.King &&
+                        From >= SquareIndex.None && From <= SquareIndex.H8 &&
+                        To >= SquareIndex.None && To <= SquareIndex.H8 &&
+                        Type >= MoveType.Normal && Type <= MoveType.Null &&
+                        Capture >= Piece.None && Capture <= Piece.Queen &&
+                        Promote >= Piece.None && Promote <= Piece.Queen;
+            }
+        }
+
         public readonly bool IsCapture
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -185,7 +199,7 @@ namespace Pedantic.Chess
 
         public static bool TryParse(Board board, ReadOnlySpan<char> sp, out Move move)
         {
-            move = Move.NullMove;
+            move = NullMove;
 
             try
             {


### PR DESCRIPTION
Score of Pedantic Dev vs Pedantic Base: 2551 - 2370 - 1720  [0.514] 6641
...      Pedantic Dev playing White: 1367 - 1074 - 879  [0.544] 3320
...      Pedantic Dev playing Black: 1184 - 1296 - 841  [0.483] 3321
...      White vs Black: 2663 - 2258 - 1720  [0.530] 6641
Elo difference: 9.5 +/- 7.2, LOS: 99.5 %, DrawRatio: 25.9 %
SPRT: llr 2.96 (100.5%), lbound -2.94, ubound 2.94 - H1 was accepted
info string depth 12 time 10.9140 nodes 17837838 nps 1634399.6701