### PR TITLE
Use SEE for capture move classification. +29 elo

### DIFF
--- a/Pedantic.UnitTests/BoardTests.cs
+++ b/Pedantic.UnitTests/BoardTests.cs
@@ -251,5 +251,35 @@ namespace Pedantic.UnitTests
             }
             Assert.AreEqual(expected, count);
         }
+
+        [TestMethod]
+        [DataRow("4k3/1pp1q1pp/2n5/4p2R/3B1b2/2QP1N2/1P2PP2/4K3 w - - 0 1", Color.White, 100)]
+        [DataRow("8/1pp1q1pp/2n2k2/4p2R/3B1b2/2QP1N2/1P2PP2/4K3 w - - 0 1", Color.White, -200)]
+        public void See0Test(string fen, Color stm, int expected)
+        {
+            Board bd = new(fen);
+            Move move = new (stm, Piece.Bishop, SquareIndex.D4, SquareIndex.E5, MoveType.Capture, Piece.Pawn);
+            int seeEval = bd.See0(move);
+            Assert.AreEqual(expected, seeEval);
+        }
+
+        [TestMethod]
+        [DataRow("8/1pp1q1pp/2n2k2/4p2R/3B1b2/2QP1N2/1P2PP2/4K1r1 w - - 0 1", false)]
+        [DataRow("8/1pp1q1pp/2n2k2/4p2R/3B4/2QP1N2/1P2PP1b/4K1r1 w - - 0 1", false)]
+        [DataRow("8/1pp1q1pp/2n2k2/4p2R/3B4/2QP4/1P1NPP1b/4K1rR w - - 0 1", true)]
+        public void See1Test(string fen, bool safe)
+        {
+            Board bd = new(fen);
+            Move move = new (Color.Black, Piece.Rook, SquareIndex.G6, SquareIndex.G1);
+            int seeEval = bd.See1(move);
+            if (safe)
+            {
+                Assert.IsTrue(seeEval <= 0);
+            }
+            else
+            {
+                Assert.IsTrue(seeEval > 0);
+            }
+        }
     }
 }

--- a/Pedantic/Chess/Bitboard.cs
+++ b/Pedantic/Chess/Bitboard.cs
@@ -120,6 +120,18 @@ namespace Pedantic.Chess
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Bitboard SetBit(SquareIndex sq)
+        {
+            return (Bitboard)BitOps.SetBit(bb, (int)sq);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Bitboard ResetBit(SquareIndex sq)
+        {
+            return (Bitboard)BitOps.ResetBit(bb, (int)sq);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(Bitboard other)
         {
             return bb == other.bb;


### PR DESCRIPTION
Score of Pedantic Dev vs Pedantic Base: 729 - 576 - 535  [0.542] 1840
...      Pedantic Dev playing White: 389 - 264 - 267  [0.568] 920
...      Pedantic Dev playing Black: 340 - 312 - 268  [0.515] 920
...      White vs Black: 701 - 604 - 535  [0.526] 1840
Elo difference: 29.0 +/- 13.4, LOS: 100.0 %, DrawRatio: 29.1 %
SPRT: llr 2.95 (100.3%), lbound -2.94, ubound 2.94 - H1 was accepted
info string depth 12 time 10.2690 nodes 14799120 nps 1441145.1943