### PR TITLE
Prune bad captures from QSearch. +22 elo

### DIFF
--- a/Pedantic/Chess/BasicSearch.cs
+++ b/Pedantic/Chess/BasicSearch.cs
@@ -446,7 +446,6 @@ namespace Pedantic.Chess
             IEnumerable<GenMove> moves = inCheck ?
                 board.Moves(ply, history, ss, list, ttMove) :
                 board.EvasionMoves(ply, history, ss, list, ttMove);
-            //IEnumerable<GenMove> moves = board.Moves(ply, ss, list, ttMove);
 
             foreach (GenMove genMove in moves)
             {
@@ -613,9 +612,17 @@ namespace Pedantic.Chess
                 }
 
                 expandedNodes++;
+                bool isCheckingMove = board.IsChecked();
+
+                if (!inCheck && !isCheckingMove && genMove.MovePhase == MoveGenPhase.BadCapture)
+                {
+                    board.UnmakeMoveNs();
+                    continue;
+                }
+
                 NodesVisited++;
                 ssItem.Move = genMove.Move;
-                ssItem.IsCheckingMove = board.IsChecked();
+                ssItem.IsCheckingMove = isCheckingMove;
 
                 score = -Quiesce(-beta, -alpha, ply + 1, qsPly + 1);
                 board.UnmakeMoveNs();


### PR DESCRIPTION
Score of Pedantic Dev vs Pedantic Base: 931 - 777 - 736  [0.532] 2444
...      Pedantic Dev playing White: 500 - 340 - 382  [0.565] 1222
...      Pedantic Dev playing Black: 431 - 437 - 354  [0.498] 1222
...      White vs Black: 937 - 771 - 736  [0.534] 2444
Elo difference: 21.9 +/- 11.5, LOS: 100.0 %, DrawRatio: 30.1 %
SPRT: llr 2.96 (100.5%), lbound -2.94, ubound 2.94 - H1 was accepted
info string depth 12 time 8.0110 nodes 10236779 nps 1277840.3445