### PR TITLE
Change tt depth type from byte to sbyte. +216 elo

### DIFF
--- a/Pedantic/Chess/TtCache.cs
+++ b/Pedantic/Chess/TtCache.cs
@@ -20,11 +20,11 @@ namespace Pedantic.Chess
             private readonly ulong data;
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public TtItem(ulong hash, short score, Bound bound, byte depth, byte age)
+            public TtItem(ulong hash, short score, Bound bound, sbyte depth, byte age)
                 : this(hash, score, bound, depth, age, Move.NullMove)
             { }
 
-            public TtItem(ulong hash, short score, Bound bound, byte depth, ushort age, Move bestMove)
+            public TtItem(ulong hash, short score, Bound bound, sbyte depth, ushort age, Move bestMove)
             {
                 data = ((ulong)bestMove & 0x01ffffffful)
                      | (((ulong)score & 0x0fffful) << 29)
@@ -43,7 +43,7 @@ namespace Pedantic.Chess
             public Move BestMove => (Move)(uint)BitOps.BitFieldExtract(data, 0, 29);
             public short Score => (short)BitOps.BitFieldExtract(data, 29, 16);
             public Bound Bound => (Bound)BitOps.BitFieldExtract(data, 45, 2);
-            public byte Depth => (byte)BitOps.BitFieldExtract(data, 47, 8);
+            public sbyte Depth => (sbyte)BitOps.BitFieldExtract(data, 47, 8);
             public ushort Age => (ushort)BitOps.BitFieldExtract(data, 55, 9);
         }
 
@@ -145,7 +145,7 @@ namespace Pedantic.Chess
                 bound = Bound.Lower;
             }
 
-            pTable[index] = new TtItem(hash, (short)score, bound, (byte)depth, generation, bestMove);
+            pTable[index] = new TtItem(hash, (short)score, bound, (sbyte)depth, generation, bestMove);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
Score of Pedantic Dev vs Pedantic Base: 89 - 16 - 27  [0.777] 132
...      Pedantic Dev playing White: 49 - 8 - 10  [0.806] 67
...      Pedantic Dev playing Black: 40 - 8 - 17  [0.746] 65
...      White vs Black: 57 - 48 - 27  [0.534] 132
Elo difference: 216.4 +/- 60.8, LOS: 100.0 %, DrawRatio: 20.5 %
SPRT: llr 2.95 (100.3%), lbound -2.94, ubound 2.94 - H1 was accepted
info string depth 12 time 9.7720 nodes 26352244 nps 2696709.3737