### PR TITLE
Internal iterative reduction (IIR) +11 elo

### DIFF
--- a/Pedantic/Chess/BasicSearch.cs
+++ b/Pedantic/Chess/BasicSearch.cs
@@ -436,6 +436,11 @@ namespace Pedantic.Chess
                 }
             }
 
+            if (!inCheck && depth >= UciOptions.IirMinDepth && ttMove == Move.NullMove)
+            {
+                depth--;
+            }
+
             Move bestMove = Move.NullMove;
             int expandedNodes = 0, bestScore = -INFINITE_WINDOW;
             history.SetContext(ply);

--- a/Pedantic/Chess/TtCache.cs
+++ b/Pedantic/Chess/TtCache.cs
@@ -20,6 +20,10 @@ namespace Pedantic.Chess
             private readonly ulong data;
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public TtItem() : this(0, 0, Bound.None, 0, 0, Move.NullMove)
+            { }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public TtItem(ulong hash, short score, Bound bound, sbyte depth, byte age)
                 : this(hash, score, bound, depth, age, Move.NullMove)
             { }
@@ -179,7 +183,7 @@ namespace Pedantic.Chess
         {
             if (!GetProbeIndex(hash, out int index))
             {
-                item = default;
+                item = new TtItem();
                 return false;
             }
             item = pTable[index];

--- a/Pedantic/Chess/UciOptions.cs
+++ b/Pedantic/Chess/UciOptions.cs
@@ -45,6 +45,7 @@ namespace Pedantic.Chess
         internal const string OPT_LMP_DEPTH_INCREMENT = "UCI_T_LMP_DepthIncrement";
         internal const string OPT_FUT_MAX_DEPTH = "UCI_T_FUT_MaxDepth";
         internal const string OPT_FUT_MARGIN = "UCI_T_FUT_Margin";
+        internal const string OPT_IIR_MIN_DEPTH = "UCI_T_IIR_MinDepth";
 
         static UciOptions()
         {
@@ -87,7 +88,8 @@ namespace Pedantic.Chess
                 { lmpMaxDepth.Name, lmpMaxDepth },
                 { lmpDepthIncrement.Name, lmpDepthIncrement },
                 { futMaxDepth.Name, futMaxDepth },
-                { futMargin.Name, futMargin }
+                { futMargin.Name, futMargin },
+                { iirMinDepth.Name, iirMinDepth }
             };
         }
 
@@ -411,6 +413,15 @@ namespace Pedantic.Chess
             }
         }
 
+        public static int IirMinDepth
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                return iirMinDepth.CurrentValue;
+            }
+        }
+
         public static void WriteLine()
         {
             foreach (var kvp in options)
@@ -526,5 +537,6 @@ namespace Pedantic.Chess
         private static UciOptionSpin lmpDepthIncrement = new UciOptionSpin(OPT_LMP_DEPTH_INCREMENT, 1, 0, 5);
         private static UciOptionSpin futMaxDepth = new UciOptionSpin(OPT_FUT_MAX_DEPTH, 7, 1, 10);
         private static UciOptionSpin futMargin = new UciOptionSpin(OPT_FUT_MARGIN, 70, 35, 200);
+        private static UciOptionSpin iirMinDepth = new UciOptionSpin(OPT_IIR_MIN_DEPTH, 5, 1, 10);
     }
 }


### PR DESCRIPTION
Score of Pedantic Dev vs Pedantic Base: 989 - 892 - 1313  [0.515] 3194
...      Pedantic Dev playing White: 527 - 405 - 665  [0.538] 1597
...      Pedantic Dev playing Black: 462 - 487 - 648  [0.492] 1597
...      White vs Black: 1014 - 867 - 1313  [0.523] 3194
Elo difference: 10.6 +/- 9.2, LOS: 98.7 %, DrawRatio: 41.1 %
SPRT: llr 2.95 (100.0%), lbound -2.94, ubound 2.94 - H1 was accepted
info string depth 12 time 7.8280 nodes 30148797 nps 3851404.8288