### PR TITLE
Change the manner that attacks are cached in evaluation. +4 elo

### DIFF
--- a/Pedantic/Chess/BasicSearch.cs
+++ b/Pedantic/Chess/BasicSearch.cs
@@ -253,6 +253,7 @@ namespace Pedantic.Chess
                     continue;
                 }
 
+                ttCache.Prefetch(board.Hash); // do prefetch before we need the ttItem
                 expandedNodes++;
                 NodesVisited++;
 
@@ -357,8 +358,6 @@ namespace Pedantic.Chess
             {
                 return Quiesce(alpha, beta, ply);
             }
-
-            ttCache.Prefetch(board.Hash); // do prefetch before we need the ttItem
 
             var rep = board.PositionRepeated();
             if (rep.Repeated || rep.OverFiftyMoves)
@@ -510,6 +509,8 @@ namespace Pedantic.Chess
                     }
                     R = LMR[Math.Min(depth, MAX_PLY - 1), Math.Min(expandedNodes - 1, LMR_MAX_MOVES - 1)];
                 }
+
+                ttCache.Prefetch(board.Hash); // do prefetch before we need the ttItem
                 
                 if (expandedNodes == 1)
                 {
@@ -596,8 +597,6 @@ namespace Pedantic.Chess
                 return eval.Compute(board);
             }
 
-            ttCache.Prefetch(board.Hash); // do prefetch before we need the ttItem
-
             var rep = board.PositionRepeated();
             if (rep.Repeated || rep.OverFiftyMoves)
             {
@@ -656,7 +655,7 @@ namespace Pedantic.Chess
                     board.UnmakeMoveNs();
                     continue;
                 }
-
+                ttCache.Prefetch(board.Hash); // do prefetch before we need the ttItem
                 ssItem.Move = genMove.Move;
                 ssItem.IsCheckingMove = isCheckingMove;
 

--- a/Pedantic/Chess/Board.cs
+++ b/Pedantic/Chess/Board.cs
@@ -1459,6 +1459,19 @@ namespace Pedantic.Chess
             return new EvasionInfo(checkerCount, kingDanger, captureMask, pushMask);
         }
 
+        public Bitboard GetXrayAttacks(Color color, Piece piece, SquareIndex from)
+        {
+            Bitboard blockers = All ^ Pieces(color, Piece.Queen);
+            blockers ^= piece switch
+            {
+                Piece.Bishop => Pieces(color, Piece.Bishop),
+                Piece.Rook => Pieces(color, Piece.Rook),
+                Piece.Queen => Pieces(color, Piece.Bishop) | Pieces(color, Piece.Rook),
+                _ => Bitboard.None
+            };
+            return GetPieceMoves(piece, from, blockers);
+        }
+
         public static Bitboard GetPieceMoves(Piece piece, SquareIndex from, Bitboard blockers)
         {
             return piece switch
@@ -1468,7 +1481,7 @@ namespace Pedantic.Chess
                 Piece.Rook => GetRookMoves(from, blockers),
                 Piece.Queen => GetQueenMoves(from, blockers),
                 Piece.King => KingMoves(from),
-                _ => (Bitboard)0ul
+                _ => Bitboard.None
             };
         }
 

--- a/Pedantic/Chess/Enums.cs
+++ b/Pedantic/Chess/Enums.cs
@@ -67,4 +67,6 @@
     public enum UciOptionType : byte { Button, Check, Combo, Spin, String }
 
     public enum Bound : byte { None, Exact, Lower, Upper }
+
+    public enum AttackBy : byte { Pawn, Knight, Bishop, Rook, Queen, King, All }
 }

--- a/Pedantic/Tuning/EvalFeatures.cs
+++ b/Pedantic/Tuning/EvalFeatures.cs
@@ -47,7 +47,8 @@ namespace Pedantic.Tuning
                     Bitboard pieceAttacks = Board.GetPieceMoves(piece, from, bd.All);
                     if (piece != Piece.Pawn && piece != Piece.King)
                     {
-                        evalInfo[c].PieceAttacks |= pieceAttacks;
+                        evalInfo[c].AttackBy[(int)piece] |= pieceAttacks;
+                        evalInfo[c].AttackBy[AttackBy.All] |= pieceAttacks;
                         if (pieceAttacks != 0 && evalInfo[c].AttackCount < HceEval.MAX_ATTACK_LEN)
                         {
                             evalInfo[c].Attacks[evalInfo[c].AttackCount++] = pieceAttacks;
@@ -72,7 +73,7 @@ namespace Pedantic.Tuning
                             IncrementPhalanxPawn(color, coefficients, normalFrom);
                         }
 
-                        if ((evalInfo[c].PawnAttacks & sqMask) != 0)
+                        if ((evalInfo[c].AttackBy[AttackBy.Pawn] & sqMask) != 0)
                         {
                             IncrementChainedPawn(color, coefficients, normalFrom);
                         }
@@ -105,7 +106,7 @@ namespace Pedantic.Tuning
                 SquareIndex enemyKI = evalInfo[o].KI;
                 for (int n = 0; n < evalInfo[c].AttackCount; n++)
                 {
-                    Bitboard attacks = evalInfo[c].Attacks[n].AndNot(evalInfo[o].PawnAttacks);
+                    Bitboard attacks = evalInfo[c].Attacks[n].AndNot(evalInfo[o].AttackBy[AttackBy.Pawn]);
                     int count = (attacks & (Bitboard)HceEval.KingProximity[0, (int)enemyKI]).PopCount;
                     IncrementKingAttack(color, coefficients, 0, count);
                     count = (attacks & (Bitboard)HceEval.KingProximity[1, (int)enemyKI]).PopCount;
@@ -173,7 +174,7 @@ namespace Pedantic.Tuning
                     IncrementPushedPawnThreat(color, coefficients, threatenedPiece);
                 }
 
-                foreach (SquareIndex sq in evalInfo[c].PawnAttacks & targets)
+                foreach (SquareIndex sq in evalInfo[c].AttackBy[AttackBy.Pawn] & targets)
                 {
                     Piece threatenedPiece = bd.PieceBoard(sq).Piece;
                     IncrementPawnThreat(color, coefficients, threatenedPiece);
@@ -211,7 +212,7 @@ namespace Pedantic.Tuning
                     }
 
                     Bitboard advanceMask = new Bitboard(Board.PawnPlus(color, ppIndex));
-                    Bitboard attacksMask = evalInfo[o].PawnAttacks | evalInfo[o].PieceAttacks | evalInfo[o].KingAttacks;
+                    Bitboard attacksMask = evalInfo[o].AttackBy[AttackBy.All];
 
                     if ((advanceMask & bd.All) == 0 && (advanceMask & attacksMask) == 0)
                     {

--- a/uci_test.txt
+++ b/uci_test.txt
@@ -3,5 +3,8 @@ setoption name Hash value 128
 setoption name SyzygyPath value c:/tb/syzygy/3-4-5-6/
 ucinewgame
 isready
-position fen r7/6k1/1p6/2pp1p2/7Q/8/p1P2K1P/8 w - - 0 32
-go
+position startpos
+go depth 18
+wait
+quit
+


### PR DESCRIPTION
Score of Pedantic Dev vs Pedantic Base: 2862 - 2751 - 3643  [0.506] 9256
...      Pedantic Dev playing White: 1605 - 1190 - 1835  [0.545] 4630
...      Pedantic Dev playing Black: 1257 - 1561 - 1808  [0.467] 4626
...      White vs Black: 3166 - 2447 - 3643  [0.539] 9256
Elo difference: 4.2 +/- 5.5, LOS: 93.1 %, DrawRatio: 39.4 %
SPRT: llr 2.95 (100.2%), lbound -2.94, ubound 2.94 - H1 was accepted
info string depth 12 time 6.6620 nodes 22697627 nps 3407028.9703