### PR TITLE
Give PV move a bonus to ensure poll position. +57 elo

### DIFF
--- a/Pedantic/Chess/BasicSearch.cs
+++ b/Pedantic/Chess/BasicSearch.cs
@@ -138,6 +138,10 @@ namespace Pedantic.Chess
                 Move ponderMove = Move.NullMove;
                 history.SetContext(0);
                 oneLegalMove = board.OneLegalMove(list, out Move bestMove);
+                if (!oneLegalMove)
+                {
+                    bestMove = Move.NullMove;
+                }
                 startDateTime = DateTime.Now;
 
                 while (++Depth <= maxDepth && clock.CanSearchDeeper())
@@ -241,6 +245,7 @@ namespace Pedantic.Chess
 
             int score;
             Move bestMove = Move.NullMove;
+            int bestMoveIndex = -1;
             bool alphaRaised = false;
             int expandedNodes = 0, bestScore = -INFINITE_WINDOW;
             board.PushBoardState();
@@ -307,6 +312,7 @@ namespace Pedantic.Chess
                 {
                     bestMove = move;
                     bestScore = score;
+                    bestMoveIndex = n;
 
                     if (score > alpha)
                     {
@@ -321,6 +327,11 @@ namespace Pedantic.Chess
                         pvTable.MergeMove(0, move);
                     }
                 }
+            }
+
+            if (bestMoveIndex >= 0)
+            {
+                list.SetScore(bestMoveIndex, PV_BONUS);
             }
 
             board.PopBoardState();
@@ -452,7 +463,7 @@ namespace Pedantic.Chess
             StackList<Move> quiets = new(stackalloc Move[64]);
             board.PushBoardState();
             MoveList list = listPool.Rent();
-            IEnumerable<GenMove> moves = inCheck ?
+            IEnumerable<GenMove> moves = !inCheck ?
                 board.Moves(ply, history, ss, list, ttMove) :
                 board.EvasionMoves(ply, history, ss, list, ttMove);
 

--- a/Pedantic/Chess/Constants.cs
+++ b/Pedantic/Chess/Constants.cs
@@ -21,6 +21,7 @@
         public const int HISTORY_SCORE_MIN = -HISTORY_SCORE_MAX;
         public const int PROMOTE_BONUS = 50000;
         public const int CAPTURE_BONUS = 60000;
+        public const int PV_BONUS = 70000;
         public const int INFINITE_WINDOW = short.MaxValue;
         public const ulong BB_ALL = 0xfffffffffffffffful;
         public const ulong BB_NONE = 0;


### PR DESCRIPTION
Score of Pedantic Dev vs Pedantic Base: 303 - 176 - 303  [0.581] 782
...      Pedantic Dev playing White: 168 - 81 - 143  [0.611] 392
...      Pedantic Dev playing Black: 135 - 95 - 160  [0.551] 390
...      White vs Black: 263 - 216 - 303  [0.530] 782
Elo difference: 56.9 +/- 19.1, LOS: 100.0 %, DrawRatio: 38.7 %
SPRT: llr 2.96 (100.7%), lbound -2.94, ubound 2.94 - H1 was accepted
info string depth 12 time 8.0730 nodes 26690425 nps 3306134.6464