### PR TITLE
Only calculate full eval if required. +21 elo

### DIFF
--- a/Pedantic/Chess/BasicSearch.cs
+++ b/Pedantic/Chess/BasicSearch.cs
@@ -363,7 +363,7 @@ namespace Pedantic.Chess
 
             if (ply >= MAX_PLY - 1)
             {
-                return eval.Compute(board);
+                return eval.Compute(board, alpha, beta);
             }
             if (depth <= 0)
             {
@@ -412,7 +412,7 @@ namespace Pedantic.Chess
 
             if (!inCheck)
             {
-                evaluation = ssItem.Eval = eval.Compute(board);
+                evaluation = ssItem.Eval = eval.Compute(board, alpha, beta);
                 if (!isPv)
                 {
                     // static null move pruning (reverse futility pruning)
@@ -605,7 +605,7 @@ namespace Pedantic.Chess
             SelDepth = Math.Max(SelDepth, ply);
             if (ply >= MAX_PLY - 1)
             {
-                return eval.Compute(board);
+                return eval.Compute(board, alpha, beta);
             }
 
             var rep = board.PositionRepeated();
@@ -629,7 +629,7 @@ namespace Pedantic.Chess
                 ttMove = ttItem.BestMove;
             }
 
-            int standPatScore = eval.Compute(board);
+            int standPatScore = eval.Compute(board, alpha, beta);
             if (!inCheck)
             {
                 if (standPatScore >= beta)

--- a/Pedantic/Chess/UciOptions.cs
+++ b/Pedantic/Chess/UciOptions.cs
@@ -49,6 +49,7 @@ namespace Pedantic.Chess
         internal const string OPT_SEE_MAX_DEPTH = "UCI_T_SEE_MaxDepth";
         internal const string OPT_SEE_CAPTURE_MARGIN = "UCI_T_SEE_CaptureMargin";
         internal const string OPT_SEE_QUIET_MARGIN = "UCI_T_SEE_QuietMargin";
+        internal const string OPT_LZY_EVAL_MARGIN = "UCI_T_LZY_EvalMargin";
 
         static UciOptions()
         {
@@ -95,7 +96,8 @@ namespace Pedantic.Chess
                 { iirMinDepth.Name, iirMinDepth },
                 { seeMaxDepth.Name, seeMaxDepth },
                 { seeCaptureMargin.Name, seeCaptureMargin },
-                { seeQuietMargin.Name, seeQuietMargin }
+                { seeQuietMargin.Name, seeQuietMargin },
+                { lzyEvalMargin.Name, lzyEvalMargin }
             };
         }
 
@@ -455,6 +457,15 @@ namespace Pedantic.Chess
             }
         }
 
+        public static int LzyEvalMargin
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                return lzyEvalMargin.CurrentValue;
+            }
+        }
+
         public static void WriteLine()
         {
             foreach (var kvp in options)
@@ -574,5 +585,6 @@ namespace Pedantic.Chess
         private static UciOptionSpin seeMaxDepth = new UciOptionSpin(OPT_SEE_MAX_DEPTH, 7, 1, 12);
         private static UciOptionSpin seeCaptureMargin = new UciOptionSpin(OPT_SEE_CAPTURE_MARGIN, 100, 25, 200);
         private static UciOptionSpin seeQuietMargin = new UciOptionSpin(OPT_SEE_QUIET_MARGIN, 60, 25, 200);
+        private static UciOptionSpin lzyEvalMargin = new UciOptionSpin(OPT_LZY_EVAL_MARGIN, 500, 0, 1200);
     }
 }


### PR DESCRIPTION
Score of Pedantic Dev vs Pedantic Base: 663 - 537 - 904  [0.530] 2104
...      Pedantic Dev playing White: 373 - 225 - 454  [0.570] 1052
...      Pedantic Dev playing Black: 290 - 312 - 450  [0.490] 1052
...      White vs Black: 685 - 515 - 904  [0.540] 2104
Elo difference: 20.8 +/- 11.2, LOS: 100.0 %, DrawRatio: 43.0 %
SPRT: llr 2.96 (100.5%), lbound -2.94, ubound 2.94 - H1 was accepted
info string depth 12 time 5.4840 nodes 22916054 nps 4178711.5244