### PR TITLE
Razoring at frontier node. +32 elo

### DIFF
--- a/Pedantic/Chess/BasicSearch.cs
+++ b/Pedantic/Chess/BasicSearch.cs
@@ -448,7 +448,22 @@ namespace Pedantic.Chess
                         ssItem.Eval = (short)evaluation;
                     }
 
-                    canPrune = canNull;
+                    if (canNull)
+                    {
+                        if (depth <= 1)
+                        {
+                            int threshold = alpha - depth * 200;
+                            if (evaluation <= threshold)
+                            {
+                                score = Quiesce(alpha, beta, ply);
+                                if (score <= alpha)
+                                {
+                                    return score;
+                                }
+                            }
+                        }
+                        canPrune = true;
+                    }
                 }
             }
 


### PR DESCRIPTION
Score of Pedantic Dev vs Pedantic Base: 436 - 314 - 561  [0.547] 1311
...      Pedantic Dev playing White: 261 - 138 - 257  [0.594] 656
...      Pedantic Dev playing Black: 175 - 176 - 304  [0.499] 655
...      White vs Black: 437 - 313 - 561  [0.547] 1311
Elo difference: 32.4 +/- 14.2, LOS: 100.0 %, DrawRatio: 42.8 %
SPRT: llr 2.95 (100.2%), lbound -2.94, ubound 2.94 - H1 was accepted
info string depth 12 time 4.7370 nodes 18171318 nps 3836039.2654