### PR TITLE
Continuation history at ply - 2 +4 elo

### DIFF
--- a/Pedantic/Chess/BasicSearch.cs
+++ b/Pedantic/Chess/BasicSearch.cs
@@ -7,7 +7,7 @@ using Pedantic.Tablebase;
 
 namespace Pedantic.Chess
 {
-    public class BasicSearch : IInitialize
+    public sealed class BasicSearch : IInitialize
     {
         internal const int CHECK_TC_NODES_MASK = 1023;
         internal const int WAIT_TIME = 50;
@@ -15,12 +15,6 @@ namespace Pedantic.Chess
         internal const double LMR_MIN = 0.0;
         internal const double LMR_MAX = 15.0;
         internal const int LMP_MAX_DEPTH_CUTOFF = 11;
-
-        private class FakeHistory : IHistory
-        {
-            public short this[Move move] => 0;
-            public short this[Color stm, Piece piece, SquareIndex to] => 0;
-        }
 
         #region Constructors
 
@@ -668,7 +662,6 @@ namespace Pedantic.Chess
             Move bestMove = Move.NullMove;
             board.PushBoardState();
             MoveList list = listPool.Rent();
-            //list.History = fakeHistory;
             int expandedNodes = 0;
 
             IEnumerable<GenMove> moves = !inCheck ? 
@@ -942,7 +935,6 @@ namespace Pedantic.Chess
         private readonly PvTable pvTable = new();
         private readonly List<Move> pv = new(MAX_PLY);
         private readonly CpuStats cpuStats = new();
-        private readonly FakeHistory fakeHistory = new();
         private Uci uci = Uci.Default;
         private bool oneLegalMove = false;
         private bool wasAborted = false;

--- a/Pedantic/Chess/History.cs
+++ b/Pedantic/Chess/History.cs
@@ -35,7 +35,9 @@ namespace Pedantic.Chess
             get
             {
                 int index = GetIndex(stm, piece, sq);
-                int value = history[index] + CH(in ss[ply - 1], index);
+                int value = history[index] 
+                          + CH(in ss[ply - 1], index)
+                          + CH(in ss[ply - 2], index);
                 return (short)Math.Clamp(value, short.MinValue, short.MaxValue);
             }
         }
@@ -46,7 +48,9 @@ namespace Pedantic.Chess
             get
             {
                 int index = GetIndex(move);
-                int value = history[GetIndex(move)] + CH(in ss[ply - 1], index);
+                int value = history[GetIndex(move)] 
+                          + CH(in ss[ply - 1], index)
+                          + CH(in ss[ply - 2], index);
                 return (short)Math.Clamp(value, short.MinValue, short.MaxValue);
 
             }
@@ -108,6 +112,7 @@ namespace Pedantic.Chess
             int index = GetIndex(move);
             UpdateHistory(ref history[index], bonus);
             UpdateHistory(ref ss[ply - 1].Continuation![index], bonus);
+            UpdateHistory(ref ss[ply - 2].Continuation![index], bonus);
 
             short malus = (short)-bonus;
             for (int n = 0; n < quiets.Count; n++)
@@ -115,6 +120,7 @@ namespace Pedantic.Chess
                 index = GetIndex(quiets[n]);
                 UpdateHistory(ref history[index], malus);
                 UpdateHistory(ref ss[ply - 1].Continuation![index], malus);
+                UpdateHistory(ref ss[ply - 2].Continuation![index], malus);
             }
 
             Move lastMove = ss[ply - 1].Move;


### PR DESCRIPTION
Score of Pedantic Dev vs Pedantic Base: 3319 - 3159 - 6048  [0.506] 12526
...      Pedantic Dev playing White: 1978 - 1256 - 3029  [0.558] 6263
...      Pedantic Dev playing Black: 1341 - 1903 - 3019  [0.455] 6263
...      White vs Black: 3881 - 2597 - 6048  [0.551] 12526
Elo difference: 4.4 +/- 4.4, LOS: 97.7 %, DrawRatio: 48.3 %
SPRT: llr 2.95 (100.1%), lbound -2.94, ubound 2.94 - H1 was accepted
info string depth 12 time 5.3230 nodes 19993046 nps 3755973.3233