### PR TITLE
Apply improving heuristic to RFP. +14 elo

### DIFF
--- a/Pedantic/Chess/BasicSearch.cs
+++ b/Pedantic/Chess/BasicSearch.cs
@@ -426,7 +426,8 @@ namespace Pedantic.Chess
             if (!inCheck && !isPv)
             {
                 // static null move pruning (reverse futility pruning)
-                if (depth <= UciOptions.RfpMaxDepth && evaluation >= beta + depth * UciOptions.RfpMargin)
+                if (depth <= UciOptions.RfpMaxDepth && 
+                    evaluation >= beta + (depth / (improving ? 2 : 1)) * UciOptions.RfpMargin)
                 {
                     return evaluation;
                 }


### PR DESCRIPTION
Score of Pedantic Dev vs Pedantic Base: 922 - 795 - 1369  [0.521] 3086
...      Pedantic Dev playing White: 504 - 346 - 693  [0.551] 1543
...      Pedantic Dev playing Black: 418 - 449 - 676  [0.490] 1543
...      White vs Black: 953 - 764 - 1369  [0.531] 3086
Elo difference: 14.3 +/- 9.1, LOS: 99.9 %, DrawRatio: 44.4 %
SPRT: llr 2.94 (100.0%), lbound -2.94, ubound 2.94 - H1 was accepted
info string depth 12 time 3.0950 nodes 12184951 nps 3936979.3215