### PR TITLE
Use eval cache to avoid re-evaluating positions. +10 elo

### DIFF
--- a/Pedantic.UnitTests/HceEvalTests.cs
+++ b/Pedantic.UnitTests/HceEvalTests.cs
@@ -67,6 +67,95 @@ namespace Pedantic.UnitTests
             short actual = eval.Compute(bd);
             Assert.AreEqual(expected, actual);
         }
+
+        [TestMethod]
+	    [DataRow("r3k2r/2pb1ppp/2pp1q2/p7/1nP1B3/1P2P3/P2N1PPP/R2QK2R w KQkq a6 0 14")]
+		[DataRow("4rrk1/2p1b1p1/p1p3q1/4p3/2P2n1p/1P1NR2P/PB3PP1/3R1QK1 b - - 2 24")]
+		[DataRow("r3qbrk/6p1/2b2pPp/p3pP1Q/PpPpP2P/3P1B2/2PB3K/R5R1 w - - 16 42")]
+		[DataRow("6k1/1R3p2/6p1/2Bp3p/3P2q1/P7/1P2rQ1K/5R2 b - - 4 44")]
+		[DataRow("8/8/1p2k1p1/3p3p/1p1P1P1P/1P2PK2/8/8 w - - 3 54")]
+		[DataRow("7r/2p3k1/1p1p1qp1/1P1Bp3/p1P2r1P/P7/4R3/Q4RK1 w - - 0 36")]
+		[DataRow("r1bq1rk1/pp2b1pp/n1pp1n2/3P1p2/2P1p3/2N1P2N/PP2BPPP/R1BQ1RK1 b - - 2 10")]
+		[DataRow("3r3k/2r4p/1p1b3q/p4P2/P2Pp3/1B2P3/3BQ1RP/6K1 w - - 3 87")]
+		[DataRow("2r4r/1p4k1/1Pnp4/3Qb1pq/8/4BpPp/5P2/2RR1BK1 w - - 0 42")]
+		[DataRow("4q1bk/6b1/7p/p1p4p/PNPpP2P/KN4P1/3Q4/4R3 b - - 0 37")]
+		[DataRow("2q3r1/1r2pk2/pp3pp1/2pP3p/P1Pb1BbP/1P4Q1/R3NPP1/4R1K1 w - - 2 34")]
+		[DataRow("1r2r2k/1b4q1/pp5p/2pPp1p1/P3Pn2/1P1B1Q1P/2R3P1/4BR1K b - - 1 37")]
+		[DataRow("r3kbbr/pp1n1p1P/3ppnp1/q5N1/1P1pP3/P1N1B3/2P1QP2/R3KB1R b KQkq b3 0 17")]
+		[DataRow("8/6pk/2b1Rp2/3r4/1R1B2PP/P5K1/8/2r5 b - - 16 42")]
+		[DataRow("1r4k1/4ppb1/2n1b1qp/pB4p1/1n1BP1P1/7P/2PNQPK1/3RN3 w - - 8 29")]
+		[DataRow("8/p2B4/PkP5/4p1pK/4Pb1p/5P2/8/8 w - - 29 68")]
+		[DataRow("3r4/ppq1ppkp/4bnp1/2pN4/2P1P3/1P4P1/PQ3PBP/R4K2 b - - 2 20")]
+		[DataRow("5rr1/4n2k/4q2P/P1P2n2/3B1p2/4pP2/2N1P3/1RR1K2Q w - - 1 49")]
+		[DataRow("1r5k/2pq2p1/3p3p/p1pP4/4QP2/PP1R3P/6PK/8 w - - 1 51")]
+		[DataRow("q5k1/5ppp/1r3bn1/1B6/P1N2P2/BQ2P1P1/5K1P/8 b - - 2 34")]
+		[DataRow("r1b2k1r/5n2/p4q2/1ppn1Pp1/3pp1p1/NP2P3/P1PPBK2/1RQN2R1 w - - 0 22")]
+		[DataRow("r1bqk2r/pppp1ppp/5n2/4b3/4P3/P1N5/1PP2PPP/R1BQKB1R w KQkq - 0 5")]
+		[DataRow("r1bqr1k1/pp1p1ppp/2p5/8/3N1Q2/P2BB3/1PP2PPP/R3K2n b Q - 1 12")]
+		[DataRow("r1bq2k1/p4r1p/1pp2pp1/3p4/1P1B3Q/P2B1N2/2P3PP/4R1K1 b - - 2 19")]
+		[DataRow("r4qk1/6r1/1p4p1/2ppBbN1/1p5Q/P7/2P3PP/5RK1 w - - 2 25")]
+		[DataRow("r7/6k1/1p6/2pp1p2/7Q/8/p1P2K1P/8 w - - 0 32")]
+		[DataRow("r3k2r/ppp1pp1p/2nqb1pn/3p4/4P3/2PP4/PP1NBPPP/R2QK1NR w KQkq - 1 5")]
+		[DataRow("3r1rk1/1pp1pn1p/p1n1q1p1/3p4/Q3P3/2P5/PP1NBPPP/4RRK1 w - - 0 12")]
+		[DataRow("5rk1/1pp1pn1p/p3Brp1/8/1n6/5N2/PP3PPP/2R2RK1 w - - 2 20")]
+		[DataRow("8/1p2pk1p/p1p1r1p1/3n4/8/5R2/PP3PPP/4R1K1 b - - 3 27")]
+		[DataRow("8/4pk2/1p1r2p1/p1p4p/Pn5P/3R4/1P3PP1/4RK2 w - - 1 33")]
+		[DataRow("8/5k2/1pnrp1p1/p1p4p/P6P/4R1PK/1P3P2/4R3 b - - 1 38")]
+		[DataRow("8/8/1p1kp1p1/p1pr1n1p/P6P/1R4P1/1P3PK1/1R6 b - - 15 45")]
+		[DataRow("8/8/1p1k2p1/p1prp2p/P2n3P/6P1/1P1R1PK1/4R3 b - - 5 49")]
+		[DataRow("8/8/1p4p1/p1p2k1p/P2npP1P/4K1P1/1P6/3R4 w - - 6 54")]
+		[DataRow("8/8/1p4p1/p1p2k1p/P2n1P1P/4K1P1/1P6/6R1 b - - 6 59")]
+		[DataRow("8/5k2/1p4p1/p1pK3p/P2n1P1P/6P1/1P6/4R3 b - - 14 63")]
+		[DataRow("8/1R6/1p1K1kp1/p6p/P1p2P1P/6P1/1Pn5/8 w - - 0 67")]
+		[DataRow("1rb1rn1k/p3q1bp/2p3p1/2p1p3/2P1P2N/PP1RQNP1/1B3P2/4R1K1 b - - 4 23")]
+		[DataRow("4rrk1/pp1n1pp1/q5p1/P1pP4/2n3P1/7P/1P3PB1/R1BQ1RK1 w - - 3 22")]
+		[DataRow("r2qr1k1/pb1nbppp/1pn1p3/2ppP3/3P4/2PB1NN1/PP3PPP/R1BQR1K1 w - - 4 12")]
+		[DataRow("2r2k2/8/4P1R1/1p6/8/P4K1N/7b/2B5 b - - 0 55")]
+		[DataRow("6k1/5pp1/8/2bKP2P/2P5/p4PNb/B7/8 b - - 1 44")]
+		[DataRow("2rqr1k1/1p3p1p/p2p2p1/P1nPb3/2B1P3/5P2/1PQ2NPP/R1R4K w - - 3 25")]
+		[DataRow("r1b2rk1/p1q1ppbp/6p1/2Q5/8/4BP2/PPP3PP/2KR1B1R b - - 2 14")]
+		[DataRow("6r1/5k2/p1b1r2p/1pB1p1p1/1Pp3PP/2P1R1K1/2P2P2/3R4 w - - 1 36")]
+		[DataRow("rnbqkb1r/pppppppp/5n2/8/2PP4/8/PP2PPPP/RNBQKBNR b KQkq c3 0 2")]
+		[DataRow("2rr2k1/1p4bp/p1q1p1p1/4Pp1n/2PB4/1PN3P1/P3Q2P/2RR2K1 w - f6 0 20")]
+		[DataRow("3br1k1/p1pn3p/1p3n2/5pNq/2P1p3/1PN3PP/P2Q1PB1/4R1K1 w - - 0 23")]
+		[DataRow("2r2b2/5p2/5k2/p1r1pP2/P2pB3/1P3P2/K1P3R1/7R w - - 23 93")]
+        public void EvalComponentTests(string fen)
+        {
+            Board bd = new Board(fen);
+            EvalFeatures features = new(bd);
+            
+            short expected = features.Compute(HceEval.Weights, Weights.PIECE_VALUES, Weights.KNIGHT_MOBILITY);
+
+            EvalCache cache = new();
+            HceEval eval = new(cache);
+
+            Span<HceEval.EvalInfo> evalInfo = stackalloc HceEval.EvalInfo[2];
+            HceEval.InitializeEvalInfo(bd, evalInfo);
+
+            Score score = eval.EvalMaterialAndPst(bd, evalInfo, Color.White);
+            score -= eval.EvalMaterialAndPst(bd, evalInfo, Color.Black);
+            short actual = score.NormalizeScore(bd.Phase);
+            actual = (short)(HceEval.ColorToSign(bd.SideToMove) * actual);
+            Assert.AreEqual(expected, actual, "Material+PST");
+
+            expected = features.Compute(HceEval.Weights, Weights.PASSED_PAWN, Weights.KING_ATTACK);
+            score = eval.ProbePawnCache(bd, evalInfo);
+            actual = score.NormalizeScore(bd.Phase);
+            actual = (short)(HceEval.ColorToSign(bd.SideToMove) * actual);
+            Assert.AreEqual(expected, actual, "Pawn Structure");
+
+            expected = features.Compute(HceEval.Weights, Weights.KNIGHT_MOBILITY, Weights.PASSED_PAWN);
+            score = HceEval.EvalMobility(bd, evalInfo, Color.White);
+            score -= HceEval.EvalMobility(bd, evalInfo, Color.Black);
+            actual = (short)(HceEval.ColorToSign(bd.SideToMove) * score.NormalizeScore(bd.Phase));
+            Assert.AreEqual(expected, actual, "Piece Mobility");
+
+            expected = features.Compute(HceEval.Weights, Weights.KING_ATTACK, Weights.KING_OUTSIDE_PP_SQUARE);
+            score = HceEval.EvalKingSafety(bd, evalInfo, Color.White);
+            score -= HceEval.EvalKingSafety(bd, evalInfo, Color.Black);
+            actual = (short)(HceEval.ColorToSign(bd.SideToMove) * score.NormalizeScore(bd.Phase));
+            Assert.AreEqual(expected, actual, "King Safety");
+        }
         
     }
 }

--- a/Pedantic/Chess/Board.cs
+++ b/Pedantic/Chess/Board.cs
@@ -505,7 +505,14 @@ namespace Pedantic.Chess
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Bitboard Units(Color color)
+        public Bitboard Units(Color color)
+        {
+            Util.Assert(color != Color.None);
+            return bitboards[(int)color + 1];
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ref Bitboard UnitsRef(Color color)
         {
             Util.Assert(color != Color.None);
             return ref bitboards[(int)color + 1];
@@ -664,7 +671,7 @@ namespace Pedantic.Chess
             board[(int)sq] = new Square(color, piece);
             Bitboard pcMask = new Bitboard(sq);
             All |= pcMask;
-            Units(color) |= pcMask;
+            UnitsRef(color) |= pcMask;
             Pieces(piece) |= pcMask;
             hash = ZobristHash.HashPiece(hash, color, piece, sq);
             material[color] += HceEval.Weights.PieceValue(piece);
@@ -690,7 +697,7 @@ namespace Pedantic.Chess
             board[(int)sq] = Square.Empty;
             Bitboard pcMask = ~new Bitboard(sq);
             All &= pcMask;
-            Units(color) &= pcMask;
+            UnitsRef(color) &= pcMask;
             Pieces(piece) &= pcMask;
             hash = ZobristHash.HashPiece(hash, color, piece, sq);
             material[color] -= HceEval.Weights.PieceValue(piece);
@@ -844,7 +851,7 @@ namespace Pedantic.Chess
 
         public void GenerateKingQuiets(SquareIndex kingIndex, MoveList list, in EvasionInfo info)
         {
-            Bitboard attacks = GetPieceMoves(Piece.King, kingIndex, All).AndNot(All | info.KingDanger);
+            Bitboard attacks = KingMoves(kingIndex).AndNot(All | info.KingDanger);
             foreach (SquareIndex to in attacks)
             {
                 list.AddQuiet(sideToMove, Piece.King, kingIndex, to);
@@ -867,7 +874,7 @@ namespace Pedantic.Chess
 
         public void GenerateKingCaptures(SquareIndex kingIndex, MoveList list, in EvasionInfo info)
         {
-            Bitboard attacks = GetPieceMoves(Piece.King, kingIndex, All) & Units(Opponent);
+            Bitboard attacks = KingMoves(kingIndex) & Units(Opponent);
             attacks = attacks.AndNot(info.KingDanger);
             foreach (SquareIndex to in attacks)
             {

--- a/Pedantic/Chess/EvalCache.cs
+++ b/Pedantic/Chess/EvalCache.cs
@@ -1,4 +1,5 @@
 ﻿using Pedantic.Utilities;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics.X86;
 
@@ -7,8 +8,9 @@ namespace Pedantic.Chess
     public unsafe sealed class EvalCache : IDisposable
     {
         public const int MB_SIZE = 1024 * 1024;
-        public const int DEFAULT_CACHE_SIZE = 4;
-        public const int PAWN_CACHE_ITEM_SIZE = 20;
+        public const int DEFAULT_CACHE_SIZE = 64;
+        public const int PAWN_CACHE_ITEM_SIZE = 16;
+        public const int EVAL_CACHE_ITEM_SIZE = 8;
         public const int MEM_ALIGNMENT = 64;
 
         [StructLayout(LayoutKind.Sequential, Pack=4)]
@@ -16,44 +18,116 @@ namespace Pedantic.Chess
         {
             public PawnCacheItem(ulong hash, Bitboard passedPawns, Score eval)
             {
-                this.hash = hash;
+                this.hash = (uint)(hash >> 32);
                 this.passedPawns = passedPawns;
                 this.eval = eval;
             }
 
-            public readonly ulong Hash => hash;
-            public readonly Bitboard PassedPawns => passedPawns;
-            public readonly Score Eval => eval;
+            public uint Hash 
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get => hash;
+            }
+
+            public Bitboard PassedPawns 
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get => passedPawns;
+            }
+
+            public Score Eval 
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get => eval;
+            }
 
             public static void SetValue(ref PawnCacheItem item, ulong hash, Bitboard passedPawns, Score eval)
             {
-                item.hash = hash;
+                item.hash = (uint)(hash >> 32);
                 item.passedPawns = passedPawns;
                 item.eval = eval;
             }
 
             public unsafe static int Size
             {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 get
                 {
                     return sizeof(PawnCacheItem);
                 }
             }
 
-            private ulong hash;
             private Bitboard passedPawns;
+            private uint hash;
             private Score eval;
+        }
+
+        [StructLayout(LayoutKind.Sequential, Pack=4)]
+        public struct EvalCacheItem
+        {
+            public EvalCacheItem(ulong hash, short evalScore, Color stm)
+            {
+                this.hash = (uint)(hash >> 32);
+                this.evalScore = evalScore;
+                this.stm = stm;
+            }
+
+            public uint Hash 
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get => hash;
+            }
+
+            public short EvalScore 
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get => evalScore;
+            }
+
+            public Color SideToMove
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get => stm;
+            }
+
+            public static void SetValue(ref EvalCacheItem item, ulong hash, short evalScore, Color stm)
+            {
+                item.hash = (uint)(hash >> 32);
+                item.evalScore = evalScore;
+                item.stm = stm;
+            }
+
+            public unsafe static int Size
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get
+                {
+                    return sizeof(EvalCacheItem);
+                }
+            }
+
+            private uint hash;
+            private short evalScore;
+            private Color stm;
         }
 
         public EvalCache(int sizeMb = DEFAULT_CACHE_SIZE)
         {
-            Util.Assert(sizeof(PawnCacheItem) == PAWN_CACHE_ITEM_SIZE);
+            Util.Assert(PawnCacheItem.Size == PAWN_CACHE_ITEM_SIZE);
+            Util.Assert(EvalCacheItem.Size == EVAL_CACHE_ITEM_SIZE);
             pPawnCache = null;
+            pEvalCache = null;
             Resize(sizeMb);
         }
 
         ~EvalCache()
         {
+            if (pEvalCache != null)
+            {
+                NativeMemory.AlignedFree(pEvalCache);
+                pEvalCache = null;
+            }
+
             if (pPawnCache != null)
             {
                 NativeMemory.AlignedFree(pPawnCache);
@@ -61,11 +135,25 @@ namespace Pedantic.Chess
             }
         }
 
+        public bool ProbeEvalCache(ulong hash, Color stm, out EvalCacheItem item)
+        {
+            int index = (int)(hash % (uint)evalSize);
+            item = pEvalCache[index];
+            return item.Hash == (uint)(hash >> 32) && item.SideToMove == stm;
+        }
+
+        public void SaveEval(ulong hash, short score, Color stm)
+        {
+            int index = (int)(hash % (uint)evalSize);
+            ref EvalCacheItem item = ref pEvalCache[index];
+            EvalCacheItem.SetValue(ref item, hash, score, stm);
+        }
+
         public bool ProbePawnCache(ulong hash, out PawnCacheItem item)
         {
             int index = (int)(hash % (uint)pawnSize);
             item = pPawnCache[index];
-            return item.Hash == hash;
+            return item.Hash == (uint)(hash >> 32);
         }
 
         public void SavePawnEval(ulong hash, Bitboard passedPawns, Score eval)
@@ -77,29 +165,38 @@ namespace Pedantic.Chess
 
         public void Resize(int sizeMb)
         {
-            sizeMb = Math.Clamp(sizeMb, 1, 128);
-            CalcCacheSizes(sizeMb, out pawnSize);
-            byteCount = (nuint)(sizeMb * MB_SIZE);
-            pPawnCache = (PawnCacheItem*)NativeMemory.AlignedRealloc(pPawnCache, byteCount, MEM_ALIGNMENT);
+            CalcCacheSizes(sizeMb, out evalSize, out pawnSize);
+            evalByteCount = (nuint)(evalSize * EvalCacheItem.Size);
+            pawnByteCount = (nuint)(pawnSize * PawnCacheItem.Size);
+            pEvalCache = (EvalCacheItem*)NativeMemory.AlignedRealloc(pEvalCache, evalByteCount, MEM_ALIGNMENT);
+            pPawnCache = (PawnCacheItem*)NativeMemory.AlignedRealloc(pPawnCache, pawnByteCount, MEM_ALIGNMENT);
             Clear();
         }
 
         public void Clear()
         {
-            NativeMemory.Clear(pPawnCache, byteCount);
+            NativeMemory.Clear(pEvalCache, evalByteCount);
+            NativeMemory.Clear(pPawnCache, pawnByteCount);
         }
 
-        public static void CalcCacheSizes(int sizeMb, out int pawnSize)
+        public static void CalcCacheSizes(int sizeMb, out int evalSize, out int pawnSize)
         {
+            sizeMb /= 4;
+            sizeMb = Math.Clamp(sizeMb, 4, 512);
+            evalSize = sizeMb * MB_SIZE / EvalCacheItem.Size;
+            sizeMb /= 4;
+            sizeMb = Math.Clamp(sizeMb, 1, 128);
             pawnSize = sizeMb * MB_SIZE / PawnCacheItem.Size;
         }
 
-        public void PrefetchPawnCache(ulong hash)
+        public void PrefetchEvalCache(ulong hash, ulong pawnHash)
         {
             if (Sse.IsSupported)
             {
-                int index = (int)(hash % (uint)pawnSize);
-                Sse.Prefetch0(pPawnCache + index);
+                int index = (int)(hash % (uint)evalSize);
+                Sse.Prefetch0(&pEvalCache[index]);
+                index = (int)(pawnHash % (uint)pawnSize);
+                Sse.Prefetch0(&pPawnCache[index]);
             }
         }
 
@@ -110,13 +207,33 @@ namespace Pedantic.Chess
                 NativeMemory.AlignedFree(pPawnCache);
                 pPawnCache = null;
             }
+
+            if (pEvalCache != null)
+            {
+                NativeMemory.AlignedFree(pEvalCache);
+                pEvalCache = null;
+            }
             GC.SuppressFinalize(this);
         }
 
-        public int PawnCacheSize => pawnSize;
+        public int PawnCacheSize 
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => pawnSize;
+        }
+
+        public int EvalCacheSize
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => evalSize;
+        }
 
         private int pawnSize;
         private PawnCacheItem* pPawnCache;
-        private nuint byteCount;
+        private nuint pawnByteCount;
+
+        private int evalSize;
+        private EvalCacheItem* pEvalCache;
+        private nuint evalByteCount;
     }
 }

--- a/Pedantic/Chess/MoveGen.cs
+++ b/Pedantic/Chess/MoveGen.cs
@@ -68,17 +68,20 @@ namespace Pedantic.Chess
 
         public GenMove Current
         {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => current;
         }
 
         object IEnumerator.Current
         {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => Current;
         }
 
         public void Dispose()
         { }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IEnumerator<GenMove> GetEnumerator()
         {
             return this;

--- a/Pedantic/Chess/SearchThreads.cs
+++ b/Pedantic/Chess/SearchThreads.cs
@@ -50,7 +50,7 @@ namespace Pedantic.Chess
 
         public void ResizeEvalCache()
         {
-            int sizeMb = UciOptions.HashTableSize / 16;
+            int sizeMb = UciOptions.HashTableSize;
             foreach (var thread in threads)
             {
                 thread.EvalCache.Resize(sizeMb);

--- a/Pedantic/Chess/TtCache.cs
+++ b/Pedantic/Chess/TtCache.cs
@@ -41,13 +41,47 @@ namespace Pedantic.Chess
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public bool IsValid(ulong hash) => Hash == hash;
 
-            public ulong Hash => hash ^ data;
-            public ulong Data => data;
-            public Move BestMove => (Move)(uint)BitOps.BitFieldExtract(data, 0, 29);
-            public short Score => (short)BitOps.BitFieldExtract(data, 29, 16);
-            public Bound Bound => (Bound)BitOps.BitFieldExtract(data, 45, 2);
-            public sbyte Depth => (sbyte)BitOps.BitFieldExtract(data, 47, 8);
-            public ushort Age => (ushort)BitOps.BitFieldExtract(data, 55, 9);
+            public ulong Hash 
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get => hash ^ data;
+            }
+
+            public ulong Data 
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get => data;
+            }
+
+            public Move BestMove 
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get => (Move)(uint)BitOps.BitFieldExtract(data, 0, 29);
+            }
+
+            public short Score 
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get => (short)BitOps.BitFieldExtract(data, 29, 16);
+            }
+
+            public Bound Bound 
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get => (Bound)BitOps.BitFieldExtract(data, 45, 2);
+            }
+
+            public sbyte Depth 
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get => (sbyte)BitOps.BitFieldExtract(data, 47, 8);
+            }
+
+            public ushort Age 
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get => (ushort)BitOps.BitFieldExtract(data, 55, 9);
+            }
         }
 
         public TtCache()

--- a/Pedantic/Tuning/EvalFeatures.cs
+++ b/Pedantic/Tuning/EvalFeatures.cs
@@ -125,14 +125,14 @@ namespace Pedantic.Tuning
 
                 if (bd.DiagonalSliders(other) != 0)
                 {
-                    Bitboard attacks = Board.GetPieceMoves(Piece.Bishop, KI, bd.All);
+                    Bitboard attacks = Board.GetBishopMoves(KI, bd.All);
                     int mobility = (attacks & evalInfo[o].MobilityArea).PopCount;
                     IncrementKsDiagonalMobility(color, coefficients, mobility);
                 }
 
                 if (bd.OrthogonalSliders(other) != 0)
                 {
-                    Bitboard attacks = Board.GetPieceMoves(Piece.Rook, KI, bd.All);
+                    Bitboard attacks = Board.GetRookMoves(KI, bd.All);
                     int mobility = (attacks & evalInfo[o].MobilityArea).PopCount;
                     IncrementKsOrthogonalMobility(color, coefficients, mobility);
                 }

--- a/uci_test.txt
+++ b/uci_test.txt
@@ -4,7 +4,7 @@ setoption name SyzygyPath value c:/tb/syzygy/3-4-5-6/
 ucinewgame
 isready
 position startpos
-go depth 18
+go depth 24
 wait
 quit
 


### PR DESCRIPTION
Score of Pedantic Dev vs Pedantic Base: 1355 - 1224 - 2218  [0.514] 4797
...      Pedantic Dev playing White: 764 - 511 - 1124  [0.553] 2399
...      Pedantic Dev playing Black: 591 - 713 - 1094  [0.475] 2398
...      White vs Black: 1477 - 1102 - 2218  [0.539] 4797
Elo difference: 9.5 +/- 7.2, LOS: 99.5 %, DrawRatio: 46.2 %
SPRT: llr 2.95 (100.3%), lbound -2.94, ubound 2.94 - H1 was accepted
info string depth 15 time 14.1860 nodes 26158521 nps 1843967.3622