### PR TITLE
Scale eval as game approaches draw by 50mr. +5 elo STC / +10 elo MTC

### DIFF
--- a/Pedantic.UnitTests/HceEvalTests.cs
+++ b/Pedantic.UnitTests/HceEvalTests.cs
@@ -60,7 +60,7 @@ namespace Pedantic.UnitTests
         public void ComputeTests(string fen)
         {
             Board bd = new Board(fen);
-            EvalFeatures features = new(bd);
+            EvalFeatures features = new(bd, HceEval.Weights);
             short expected = features.Compute(HceEval.Weights);
             EvalCache cache = new();
             HceEval eval = new(cache);
@@ -122,9 +122,9 @@ namespace Pedantic.UnitTests
         public void EvalComponentTests(string fen)
         {
             Board bd = new Board(fen);
-            EvalFeatures features = new(bd);
+            EvalFeatures features = new(bd, HceEval.Weights);
             
-            short expected = features.Compute(HceEval.Weights, Weights.PIECE_VALUES, Weights.KNIGHT_MOBILITY);
+            short expected = features.Compute(HceEval.Weights, Weights.PIECE_VALUES, Weights.KNIGHT_MOBILITY, false);
 
             EvalCache cache = new();
             HceEval eval = new(cache);
@@ -138,19 +138,19 @@ namespace Pedantic.UnitTests
             actual = (short)(HceEval.ColorToSign(bd.SideToMove) * actual);
             Assert.AreEqual(expected, actual, "Material+PST");
 
-            expected = features.Compute(HceEval.Weights, Weights.PASSED_PAWN, Weights.KING_ATTACK);
+            expected = features.Compute(HceEval.Weights, Weights.PASSED_PAWN, Weights.KING_ATTACK, false);
             score = eval.ProbePawnCache(bd, evalInfo);
             actual = score.NormalizeScore(bd.Phase);
             actual = (short)(HceEval.ColorToSign(bd.SideToMove) * actual);
             Assert.AreEqual(expected, actual, "Pawn Structure");
 
-            expected = features.Compute(HceEval.Weights, Weights.KNIGHT_MOBILITY, Weights.PASSED_PAWN);
+            expected = features.Compute(HceEval.Weights, Weights.KNIGHT_MOBILITY, Weights.PASSED_PAWN, false);
             score = HceEval.EvalMobility(bd, evalInfo, Color.White);
             score -= HceEval.EvalMobility(bd, evalInfo, Color.Black);
             actual = (short)(HceEval.ColorToSign(bd.SideToMove) * score.NormalizeScore(bd.Phase));
             Assert.AreEqual(expected, actual, "Piece Mobility");
 
-            expected = features.Compute(HceEval.Weights, Weights.KING_ATTACK, Weights.KING_OUTSIDE_PP_SQUARE);
+            expected = features.Compute(HceEval.Weights, Weights.KING_ATTACK, Weights.KING_OUTSIDE_PP_SQUARE, false);
             score = HceEval.EvalKingSafety(bd, evalInfo, Color.White);
             score -= HceEval.EvalKingSafety(bd, evalInfo, Color.Black);
             actual = (short)(HceEval.ColorToSign(bd.SideToMove) * score.NormalizeScore(bd.Phase));

--- a/Pedantic/Chess/BasicSearch.cs
+++ b/Pedantic/Chess/BasicSearch.cs
@@ -215,7 +215,7 @@ namespace Pedantic.Chess
             catch (Exception ex)
             {
                 string msg =
-                    $"Search: Unexpected exception occurred on position '{position}'.";
+                    $"[{DateTime.Now}]\nSearch: Unexpected exception occurred on position '{position}' : {ex.Message}";
                 Console.Error.WriteLine(msg);
                 Console.Error.WriteLine(ex.ToString());
                 Uci.Log(msg);

--- a/Pedantic/Tuning/GdTuner.cs
+++ b/Pedantic/Tuning/GdTuner.cs
@@ -259,7 +259,8 @@ namespace Pedantic.Tuning
             }
 
             double phase = p.Features.Phase;
-            return (opening * phase + endgame * (Constants.MAX_PHASE - phase)) / Constants.MAX_PHASE;
+            double eval = (opening * phase + endgame * (MAX_PHASE - phase)) / MAX_PHASE;
+            return eval * p.Features.DrawRatio.Scale / p.Features.DrawRatio.Divisor;
         }
 
         private readonly WeightPair[] weights;

--- a/Pedantic/Tuning/PosRecord.cs
+++ b/Pedantic/Tuning/PosRecord.cs
@@ -24,7 +24,7 @@ namespace Pedantic.Tuning
         {
             progress = ply * 1000 / gamePly;
             Eval = eval;
-            Features = new EvalFeatures(new Board(fen));
+            Features = new EvalFeatures(new Board(fen), Engine.Weights);
             result = fResult switch
             {
                 WDL_WIN => 2,
@@ -38,7 +38,7 @@ namespace Pedantic.Tuning
         {
             progress = (ply * 1000) / gamePly;
             Eval = eval;
-            Features = new EvalFeatures(new Board(fen));
+            Features = new EvalFeatures(new Board(fen), Engine.Weights);
             result = fResult switch
             {
                 WDL_WIN => 2,


### PR DESCRIPTION
Score of Pedantic Dev vs Pedantic Base: 1013 - 896 - 1998  [0.515] 3907
...      Pedantic Dev playing White: 577 - 393 - 983  [0.547] 1953
...      Pedantic Dev playing Black: 436 - 503 - 1015  [0.483] 1954
...      White vs Black: 1080 - 829 - 1998  [0.532] 3907
Elo difference: 10.4 +/- 7.6, LOS: 99.6 %, DrawRatio: 51.1 %
SPRT: llr 2.95 (100.3%), lbound -2.94, ubound 2.94 - H1 was accepted
nfo string depth 15 time 14.2650 nodes 26366067 nps 1848304.7319