### PR TITLE
Do not prune if need to escape potential mate. +2 elo

### DIFF
--- a/Pedantic/Chess/BasicSearch.cs
+++ b/Pedantic/Chess/BasicSearch.cs
@@ -555,7 +555,7 @@ namespace Pedantic.Chess
                 int R = 0;
                 if (!interesting)
                 {
-                    if (canPrune)
+                    if (canPrune && bestScore > MAX_TABLEBASE_LOSS)
                     { 
                         // futility pruning
                         if (depth <= UciOptions.FutMaxDepth && !genMove.Move.IsPawnMove && 


### PR DESCRIPTION
Score of Pedantic Dev vs Pedantic Base: 8436 - 8287 - 17657  [0.502] 34380
...      Pedantic Dev playing White: 4610 - 3728 - 8853  [0.526] 17191
...      Pedantic Dev playing Black: 3826 - 4559 - 8804  [0.479] 17189
...      White vs Black: 9169 - 7554 - 17657  [0.523] 34380
Elo difference: 1.5 +/- 2.6, LOS: 87.5 %, DrawRatio: 51.4 %
SPRT: llr 2.94 (100.0%), lbound -2.94, ubound 2.94 - H1 was accepted
info string depth 15 time 10.4660 nodes 19408768 nps 1854459.0101