### PR TITLE
If not improving increase lmr reduction. +6 elo

### DIFF
--- a/Pedantic/Chess/BasicSearch.cs
+++ b/Pedantic/Chess/BasicSearch.cs
@@ -597,10 +597,12 @@ namespace Pedantic.Chess
                             }
                         }
                     }
-                    R = LMR[Math.Min(depth, MAX_PLY - 1), Math.Min(expandedNodes - 1, LMR_MAX_MOVES - 1)];
-                    if (R > 0 && checkingMove)
+                    if (depth >= 3)
                     {
-                        R--;
+                        R = LMR[Math.Min(depth, MAX_PLY - 1), Math.Min(expandedNodes - 1, LMR_MAX_MOVES - 1)];
+                        R += !improving ? 1 : 0;
+                        R -= checkingMove ? 1 : 0;
+                        R = Math.Clamp(R, 0, depth - 1);
                     }
                 }
 


### PR DESCRIPTION
Score of Pedantic Dev vs Pedantic Base: 1347 - 1245 - 3108  [0.509] 5700
...      Pedantic Dev playing White: 767 - 552 - 1531  [0.538] 2850
...      Pedantic Dev playing Black: 580 - 693 - 1577  [0.480] 2850
...      White vs Black: 1460 - 1132 - 3108  [0.529] 5700
Elo difference: 6.2 +/- 6.1, LOS: 97.7 %, DrawRatio: 54.5 %
SPRT: llr 2.97 (100.9%), lbound -2.94, ubound 2.94 - H1 was accepted
info string depth 15 time 5.3170 nodes 8109269 nps 1525158.7361