### PR TITLE
Simple check extension. +7 elo

### DIFF
--- a/Pedantic/Chess/BasicSearch.cs
+++ b/Pedantic/Chess/BasicSearch.cs
@@ -396,6 +396,7 @@ namespace Pedantic.Chess
         {
             pvTable.InitPly(ply);
             SelDepth = Math.Max(SelDepth, ply);
+            bool inCheck = ss[ply - 1].IsCheckingMove;
 
             if (wasAborted || MustAbort)
             {
@@ -403,10 +404,16 @@ namespace Pedantic.Chess
                 return 0;
             }
 
+            if (inCheck)
+            {
+                depth++;
+            }
+
             if (ply >= MAX_PLY - 1)
             {
                 return eval.Compute(board, alpha, beta);
             }
+
             if (depth <= 0)
             {
                 return Quiesce(alpha, beta, ply);
@@ -422,7 +429,6 @@ namespace Pedantic.Chess
             int originalAlpha = alpha;
             bool isPv = beta - alpha > 1;
             bool allNode = !isPv && !cutNode;
-            bool inCheck = ss[ply - 1].IsCheckingMove;
             bool canPrune = false;
             ref SearchItem ssItem = ref ss[ply];
             int evaluation = ssItem.Eval = NO_SCORE;


### PR DESCRIPTION
Score of Pedantic Dev vs Pedantic Base: 1200 - 1098 - 2656  [0.510] 4954
...      Pedantic Dev playing White: 673 - 488 - 1317  [0.537] 2478
...      Pedantic Dev playing Black: 527 - 610 - 1339  [0.483] 2476
...      White vs Black: 1283 - 1015 - 2656  [0.527] 4954
Elo difference: 7.2 +/- 6.6, LOS: 98.3 %, DrawRatio: 53.6 %
SPRT: llr 2.94 (100.0%), lbound -2.94, ubound 2.94 - H1 was accepted
info string depth 15 time 5.8910 nodes 9862164 nps 1674106.9428