### PR TITLE
Decrease lmr reductions for pv nodes +10 elo

### DIFF
--- a/Pedantic/Chess/BasicSearch.cs
+++ b/Pedantic/Chess/BasicSearch.cs
@@ -608,6 +608,7 @@ namespace Pedantic.Chess
                         R = LMR[Math.Min(depth, MAX_PLY - 1), Math.Min(expandedNodes - 1, LMR_MAX_MOVES - 1)];
                         R += !improving ? 1 : 0;
                         R -= checkingMove ? 1 : 0;
+                        R -= isPv ? 1 : 0;
                         R = Math.Clamp(R, 0, depth - 1);
                     }
                 }

--- a/Pedantic/Chess/History.cs
+++ b/Pedantic/Chess/History.cs
@@ -50,7 +50,6 @@ namespace Pedantic.Chess
                           + CH(in ss[ply - 1], index)
                           + CH(in ss[ply - 2], index);
                 return (short)Math.Clamp(value, short.MinValue, short.MaxValue);
-
             }
         }
 


### PR DESCRIPTION
Score of Pedantic Dev vs Pedantic Base: 795 - 700 - 1908  [0.514] 3403
...      Pedantic Dev playing White: 437 - 305 - 960  [0.539] 1702
...      Pedantic Dev playing Black: 358 - 395 - 948  [0.489] 1701
...      White vs Black: 832 - 663 - 1908  [0.525] 3403
Elo difference: 9.7 +/- 7.7, LOS: 99.3 %, DrawRatio: 56.1 %
SPRT: llr 2.96 (100.4%), lbound -2.94, ubound 2.94 - H1 was accepted
info string depth 15 time 7.5980 nodes 11766202 nps 1548591.9979