### PR TITLE
Adjust lmr reductions based on current move's history. +10 elo

### DIFF
--- a/Pedantic/Chess/BasicSearch.cs
+++ b/Pedantic/Chess/BasicSearch.cs
@@ -559,6 +559,7 @@ namespace Pedantic.Chess
                 expandedNodes++;
                 bool checkingMove = board.IsChecked();
                 bool isQuiet = genMove.Move.IsQuiet;
+                int hist = history.GetHistory(ply, genMove.Move);
                 ssItem.Move = genMove.Move;
                 ssItem.IsCheckingMove = checkingMove;
                 ssItem.Continuation = history.GetContinuation(genMove.Move);
@@ -609,6 +610,7 @@ namespace Pedantic.Chess
                         R += !improving ? 1 : 0;
                         R -= checkingMove ? 1 : 0;
                         R -= isPv ? 1 : 0;
+                        R -= hist / UciOptions.LmrHistoryDiv;
                         R = Math.Clamp(R, 0, depth - 1);
                     }
                 }

--- a/Pedantic/Chess/History.cs
+++ b/Pedantic/Chess/History.cs
@@ -53,6 +53,12 @@ namespace Pedantic.Chess
             }
         }
 
+        public short GetHistory(int ply, Move move)
+        {
+            SetContext(ply);
+            return this[move];
+        }
+
 	    public short[]? NullMoveContinuation
 	    {
 		    [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Pedantic/Chess/UciOptions.cs
+++ b/Pedantic/Chess/UciOptions.cs
@@ -39,6 +39,7 @@ namespace Pedantic.Chess
         internal const string OPT_LMR_DEPTH_FACTOR = "T_LMR_DepthFactor";
         internal const string OPT_LMR_MOVE_FACTOR = "T_LMR_MoveFactor";
         internal const string OPT_LMR_SCALE_FACTOR = "T_LMR_ScaleFactor";
+        internal const string OPT_LMR_HISTORY_DIV = "T_LMR_HistoryDiv";
         internal const string OPT_RFP_MAX_DEPTH = "T_RFP_MaxDepth";
         internal const string OPT_RFP_MARGIN = "T_RFP_Margin";
         internal const string OPT_LMP_MAX_DEPTH = "T_LMP_MaxDepth";
@@ -92,6 +93,7 @@ namespace Pedantic.Chess
                 { lmrDepthFactor.Name, lmrDepthFactor },
                 { lmrMoveFactor.Name, lmrMoveFactor },
                 { lmrScaleFactor.Name, lmrScaleFactor },
+                { lmrHistoryDiv.Name, lmrHistoryDiv },
                 { rfpMaxDepth.Name, rfpMaxDepth },
                 { rfpMargin.Name, rfpMargin },
                 { lmpMaxDepth.Name, lmpMaxDepth },
@@ -401,6 +403,15 @@ namespace Pedantic.Chess
             }
         }
 
+        public static int LmrHistoryDiv
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                return lmrHistoryDiv.CurrentValue;
+            }
+        }
+
         public static int RfpMaxDepth
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -669,5 +680,6 @@ namespace Pedantic.Chess
         private static UciOptionSpin rzrMargin = new UciOptionSpin(OPT_RZR_MARGIN, 114, 50, 400);
         private static UciOptionSpin hisMaxBonus = new UciOptionSpin(OPT_HIS_MAX_BONUS, 919, 500, 2500);
         private static UciOptionSpin hisBonusCoefficient = new UciOptionSpin(OPT_HIS_BONUS_COEFF, 108, 50, 250);
+        private static UciOptionSpin lmrHistoryDiv = new UciOptionSpin(OPT_LMR_HISTORY_DIV, 8192, 2048, 16384);
     }
 }


### PR DESCRIPTION
Score of Pedantic Dev vs Pedantic Base: 757 - 665 - 1947  [0.514] 3369
...      Pedantic Dev playing White: 417 - 281 - 986  [0.540] 1684
...      Pedantic Dev playing Black: 340 - 384 - 961  [0.487] 1685
...      White vs Black: 801 - 621 - 1947  [0.527] 3369
Elo difference: 9.5 +/- 7.6, LOS: 99.3 %, DrawRatio: 57.8 %
SPRT: llr 2.98 (101.0%), lbound -2.94, ubound 2.94 - H1 was accepted
info string depth 15 time 8.9650 nodes 14075983 nps 1570104.0714