### PR TITLE
Add continuation history at ply - 4. +8 elo

### DIFF
--- a/Pedantic/Chess/History.cs
+++ b/Pedantic/Chess/History.cs
@@ -35,7 +35,8 @@ namespace Pedantic.Chess
                 int index = GetIndex(stm, piece, sq);
                 int value = history[index] 
                           + CH(in ss[ply - 1], index)
-                          + CH(in ss[ply - 2], index);
+                          + CH(in ss[ply - 2], index)
+                          + CH(in ss[ply - 4], index);
                 return (short)Math.Clamp(value, short.MinValue, short.MaxValue);
             }
         }
@@ -48,7 +49,8 @@ namespace Pedantic.Chess
                 int index = GetIndex(move);
                 int value = history[GetIndex(move)] 
                           + CH(in ss[ply - 1], index)
-                          + CH(in ss[ply - 2], index);
+                          + CH(in ss[ply - 2], index)
+                          + CH(in ss[ply - 4], index);
                 return (short)Math.Clamp(value, short.MinValue, short.MaxValue);
             }
         }
@@ -116,6 +118,7 @@ namespace Pedantic.Chess
             UpdateHistory(ref history[index], bonus);
             UpdateHistory(ref ss[ply - 1].Continuation![index], bonus);
             UpdateHistory(ref ss[ply - 2].Continuation![index], bonus);
+            UpdateHistory(ref ss[ply - 4].Continuation![index], bonus);
 
             short malus = (short)-bonus;
             for (int n = 0; n < quiets.Count; n++)
@@ -124,6 +127,7 @@ namespace Pedantic.Chess
                 UpdateHistory(ref history[index], malus);
                 UpdateHistory(ref ss[ply - 1].Continuation![index], malus);
                 UpdateHistory(ref ss[ply - 2].Continuation![index], malus);
+                UpdateHistory(ref ss[ply - 4].Continuation![index], malus);
             }
 
             Move lastMove = ss[ply - 1].Move;


### PR DESCRIPTION
Score of Pedantic Dev vs Pedantic Base: 802 - 713 - 2204  [0.512] 3719
...      Pedantic Dev playing White: 447 - 322 - 1090  [0.534] 1859
...      Pedantic Dev playing Black: 355 - 391 - 1114  [0.490] 1860
...      White vs Black: 838 - 677 - 2204  [0.522] 3719
Elo difference: 8.3 +/- 7.1, LOS: 98.9 %, DrawRatio: 59.3 %
SPRT: llr 2.96 (100.5%), lbound -2.94, ubound 2.94 - H1 was accepted
info string depth 15 time 8.4320 nodes 12129669 nps 1438528.1072