### PR TITLE
Don't trust mate scores returned in NMP. +3 elo

### DIFF
--- a/Pedantic.UnitTests/BoardTests.cs
+++ b/Pedantic.UnitTests/BoardTests.cs
@@ -260,8 +260,13 @@ namespace Pedantic.UnitTests
         {
             Board bd = new(fen);
             Move move = new (stm, Piece.Bishop, SquareIndex.D4, SquareIndex.E5, MoveType.Capture, Piece.Pawn);
-            int seeEval = bd.See0(move);
-            Assert.AreEqual(expected, seeEval);
+
+            int see0Eval = bd.See0(move);
+            //Assert.AreEqual(expected, seeEval);
+
+            bd.MakeMove(move);
+            int see1Eval = bd.See1(move);
+            Assert.AreEqual(move.Capture.Value() - see0Eval, see1Eval);
         }
 
         [TestMethod]

--- a/Pedantic/Chess/BasicSearch.cs
+++ b/Pedantic/Chess/BasicSearch.cs
@@ -507,7 +507,8 @@ namespace Pedantic.Chess
 
                         if (score >= beta)
                         {
-                            ttCache.Store(board.Hash, depth, ply, alpha, beta, score, Move.NullMove);
+                            // don't trust mate scores
+                            score = Math.Abs(score) > TABLEBASE_WIN ? beta : score;
                             return score;
                         }
                     }


### PR DESCRIPTION
Score of Pedantic Dev vs Pedantic Base: 1836 - 1758 - 4672  [0.505] 8266
...      Pedantic Dev playing White: 993 - 792 - 2347  [0.524] 4132
...      Pedantic Dev playing Black: 843 - 966 - 2325  [0.485] 4134
...      White vs Black: 1959 - 1635 - 4672  [0.520] 8266
Elo difference: 3.3 +/- 4.9, LOS: 90.3 %, DrawRatio: 56.5 %
SPRT: llr 2.98 (101.1%), lbound -2.94, ubound 2.94 - H1 was accepted
info string depth 15 time 8.6820 nodes 14058749 nps 1619298.4335