### PR TITLE
Return mate scores from quiesce search. +19 elo

### DIFF
--- a/Pedantic/Chess/BasicSearch.cs
+++ b/Pedantic/Chess/BasicSearch.cs
@@ -744,8 +744,7 @@ namespace Pedantic.Chess
             MoveList list = listPool.Rent();
             int expandedNodes = 0;
 
-            MoveGenType type = inCheck ? MoveGenType.Evasion : MoveGenType.QSearch;
-            var moves = new MoveGen(type, board, ply, history, ss, list, ttMove, qsPly);
+            var moves = new MoveGen(MoveGenType.QSearch, board, ply, history, ss, list, ttMove, qsPly);
 
             while (moves.MoveNext())
             {
@@ -801,6 +800,11 @@ namespace Pedantic.Chess
             if (wasAborted)
             {
                 return 0;
+            }
+
+            if (expandedNodes == 0 && inCheck)
+            {
+                return -CHECKMATE_SCORE + ply;
             }
 
             ttCache.Store(board.Hash, -qsPly, ply, originalAlpha, beta, bestScore, bestMove);


### PR DESCRIPTION
Score of Pedantic Dev vs Pedantic Base: 373 - 285 - 918  [0.528] 1576
...      Pedantic Dev playing White: 202 - 137 - 449  [0.541] 788
...      Pedantic Dev playing Black: 171 - 148 - 469  [0.515] 788
...      White vs Black: 350 - 308 - 918  [0.513] 1576
Elo difference: 19.4 +/- 11.1, LOS: 100.0 %, DrawRatio: 58.2 %
SPRT: llr 2.97 (101.0%), lbound -2.94, ubound 2.94 - H1 was accepted
info string depth 15 time 6.8710 nodes 10878594 nps 1583262.1161