### PR TITLE
Improve QSearch (increase full capture depth from 6 to 8) +6 elo

### DIFF
--- a/Pedantic/Chess/UciOptions.cs
+++ b/Pedantic/Chess/UciOptions.cs
@@ -127,7 +127,7 @@ namespace Pedantic.Chess
                     sw.WriteLine($"        \"value\": {spin.CurrentValue},");
                     sw.WriteLine($"        \"min_value\": {spin.MinValue},");
                     sw.WriteLine($"        \"max_value\": {spin.MaxValue},");
-                    int step = Math.Max((spin.MaxValue - spin.MinValue) / 10, 1);
+                    int step = Math.Max((spin.MaxValue - spin.MinValue) / 8, 1);
                     sw.WriteLine($"        \"step\": {step}");
                     sw.WriteLine("    },");
                 }
@@ -657,8 +657,8 @@ namespace Pedantic.Chess
         private static UciOptionSpin tmDifficultyMax = new UciOptionSpin(OPT_TM_DIFFICULTY_MAX, 200, 100, 300);
         private static UciOptionSpin aspMinDepth = new UciOptionSpin(OPT_ASP_MIN_DEPTH, 4, 1, 10);
         private static UciOptionSpin oneMoveMaxDepth = new UciOptionSpin(OPT_ONE_MOVE_MAX_DEPTH, 13, 1, 20);
-        private static UciOptionSpin recaptureDepth = new UciOptionSpin(OPT_QS_RECAPTURE_DEPTH, 6, 4, 8);
-        private static UciOptionSpin promotionDepth = new UciOptionSpin(OPT_QS_PROMOTION_DEPTH, 1, 0, 8);
+        private static UciOptionSpin recaptureDepth = new UciOptionSpin(OPT_QS_RECAPTURE_DEPTH, 8, 4, 10);
+        private static UciOptionSpin promotionDepth = new UciOptionSpin(OPT_QS_PROMOTION_DEPTH, 2, 0, 8);
         private static UciOptionSpin nmpMinDepth = new UciOptionSpin(OPT_NMP_MIN_DEPTH, 3, 3, 6);
         private static UciOptionSpin nmpBaseReduction = new UciOptionSpin(OPT_NMP_BASE_REDUCTION, 4, 1, 8);
         private static UciOptionSpin nmpIncDivisor = new UciOptionSpin(OPT_NMP_INC_DIVISOR, 5, 2, 8);


### PR DESCRIPTION
TC 10+0.1
Score of Pedantic Dev vs Pedantic Base: 2187 - 2084 - 5678  [0.505] 9949
...      Pedantic Dev playing White: 1347 - 931 - 2698  [0.542] 4976
...      Pedantic Dev playing Black: 840 - 1153 - 2980  [0.469] 4973
...      White vs Black: 2500 - 1771 - 5678  [0.537] 9949
Elo difference: 3.6 +/- 4.5, LOS: 94.2 %, DrawRatio: 57.1 %
SPRT: llr 2.97 (101.0%), lbound -2.94, ubound 2.94 - H1 was accepted
TC 15+0.15
Score of Pedantic Dev vs Pedantic Base: 1069 - 981 - 3163  [0.508] 5213
...      Pedantic Dev playing White: 610 - 437 - 1559  [0.533] 2606
...      Pedantic Dev playing Black: 459 - 544 - 1604  [0.484] 2607
...      White vs Black: 1154 - 896 - 3163  [0.525] 5213
Elo difference: 5.9 +/- 5.9, LOS: 97.4 %, DrawRatio: 60.7 %
SPRT: llr 2.95 (100.1%), lbound -2.94, ubound 2.94 - H1 was accepted
info string depth 15 time 8.0780 nodes 12432010 nps 1538996.0386