### PR TITLE
Remove !checkingMove from prune guard. +9 elo

### DIFF
--- a/Pedantic/Chess/BasicSearch.cs
+++ b/Pedantic/Chess/BasicSearch.cs
@@ -739,6 +739,7 @@ namespace Pedantic.Chess
 
             int score;
             int bestScore = standPatScore;
+            int futility = standPatScore + UciOptions.QsFutilityMargin;
             Move bestMove = Move.NullMove;
             board.PushBoardState();
             MoveList list = listPool.Rent();
@@ -757,11 +758,22 @@ namespace Pedantic.Chess
                 expandedNodes++;
                 bool isCheckingMove = board.IsChecked();
 
-                if (!inCheck && !isCheckingMove && genMove.MovePhase == MoveGenPhase.BadCapture)
+                if (!inCheck && bestScore > MAX_TABLEBASE_LOSS)
                 {
-                    board.UnmakeMoveNs();
-                    continue;
+                    if (genMove.MovePhase >= MoveGenPhase.BadCapture)
+                    {
+                        board.UnmakeMoveNs();
+                        continue;
+                    }
+
+                    //if (!genMove.Move.IsPromotionThreat && 
+                    //    futility + HceEval.Weights.PieceValue(genMove.Move.Piece).NormalizeScore(board.Phase) <= alpha)
+                    //{
+                    //    board.UnmakeMoveNs();
+                    //    continue;
+                    //}
                 }
+
                 ttCache.Prefetch(board.Hash); // do prefetch before we need the ttItem
                 eval.Prefetch(board);
                 NodesVisited++;

--- a/Pedantic/Chess/Move.cs
+++ b/Pedantic/Chess/Move.cs
@@ -167,6 +167,15 @@ namespace Pedantic.Chess
             }
         }
 
+        public readonly bool IsPromotionThreat
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                return IsPromote || (IsPawnMove && To.Normalize(Stm).Rank() == Rank.Rank7);
+            }
+        }
+
         public readonly bool Equals(Move other)
         {
             return move == other.move;

--- a/Pedantic/Chess/UciOptions.cs
+++ b/Pedantic/Chess/UciOptions.cs
@@ -33,6 +33,7 @@ namespace Pedantic.Chess
         internal const string OPT_ONE_MOVE_MAX_DEPTH = "T_OneMoveMaxDepth";
         internal const string OPT_QS_RECAPTURE_DEPTH = "T_QS_RecaptureDepth";
         internal const string OPT_QS_PROMOTION_DEPTH = "T_QS_PromotionDepth";
+        internal const string OPT_QS_FUTILITY_MARGIN = "T_QS_FutilityMargin";
         internal const string OPT_NMP_MIN_DEPTH = "T_NMP_MinDepth";
         internal const string OPT_NMP_BASE_REDUCTION = "T_NMP_BaseReduction";
         internal const string OPT_NMP_INC_DIVISOR = "T_NMP_IncDivisor";
@@ -109,6 +110,7 @@ namespace Pedantic.Chess
                 { rzrMargin.Name, rzrMargin },
                 { hisMaxBonus.Name, hisMaxBonus },
                 { hisBonusCoefficient.Name, hisBonusCoefficient },
+                { qsFutilityMargin.Name, qsFutilityMargin },
             };
         }
 
@@ -547,6 +549,15 @@ namespace Pedantic.Chess
             }
         }
 
+        public static int QsFutilityMargin
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                return qsFutilityMargin.CurrentValue;
+            }
+        }
+
         public static bool Optimizing
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -681,5 +692,6 @@ namespace Pedantic.Chess
         private static UciOptionSpin hisMaxBonus = new UciOptionSpin(OPT_HIS_MAX_BONUS, 745, 500, 2500);
         private static UciOptionSpin hisBonusCoefficient = new UciOptionSpin(OPT_HIS_BONUS_COEFF, 158, 50, 250);
         private static UciOptionSpin lmrHistoryDiv = new UciOptionSpin(OPT_LMR_HISTORY_DIV, 5815, 2048, 16384);
+        private static UciOptionSpin qsFutilityMargin = new UciOptionSpin(OPT_QS_FUTILITY_MARGIN, 150, 25, 225);
     }
 }


### PR DESCRIPTION
Score of Pedantic Dev vs Pedantic Base: 1001 - 897 - 2064  [0.513] 3962
...      Pedantic Dev playing White: 598 - 369 - 1014  [0.558] 1981
...      Pedantic Dev playing Black: 403 - 528 - 1050  [0.468] 1981
...      White vs Black: 1126 - 772 - 2064  [0.545] 3962
Elo difference: 9.1 +/- 7.5, LOS: 99.2 %, DrawRatio: 52.1 %
SPRT: llr 2.96 (100.4%), lbound -2.94, ubound 2.94 - H1 was accepted
info string depth 15 time 7.1180 nodes 11231927 nps 1577961.0846