### PR TITLE
Generate evasion moves when in check inside Quiescence search. +12 elo

### DIFF
--- a/Pedantic/Chess/BasicSearch.cs
+++ b/Pedantic/Chess/BasicSearch.cs
@@ -738,13 +738,13 @@ namespace Pedantic.Chess
             }
 
             int score;
-            int bestScore = standPatScore;
+            int bestScore = inCheck ? -INFINITE_WINDOW : alpha;
             Move bestMove = Move.NullMove;
             board.PushBoardState();
             MoveList list = listPool.Rent();
             int expandedNodes = 0;
 
-            var moves = new MoveGen(MoveGenType.QSearch, board, ply, history, ss, list, ttMove, qsPly);
+            var moves = new MoveGen(inCheck ? MoveGenType.Evasion : MoveGenType.QSearch, board, ply, history, ss, list, ttMove, qsPly);
 
             while (moves.MoveNext())
             {
@@ -755,7 +755,6 @@ namespace Pedantic.Chess
                 }
 
                 expandedNodes++;
-                bool isCheckingMove = board.IsChecked();
 
                 if (!inCheck && bestScore > MAX_TABLEBASE_LOSS && genMove.MovePhase >= MoveGenPhase.BadCapture)
                 {
@@ -767,7 +766,7 @@ namespace Pedantic.Chess
                 eval.Prefetch(board);
                 NodesVisited++;
                 ssItem.Move = genMove.Move;
-                ssItem.IsCheckingMove = isCheckingMove;
+                ssItem.IsCheckingMove = board.IsChecked();
                 ssItem.Continuation = history.GetContinuation(genMove.Move);
 
                 score = -Quiesce(-beta, -alpha, ply + 1, qsPly + 1);


### PR DESCRIPTION
Score of Pedantic Dev vs Pedantic Base: 731 - 630 - 1530  [0.517] 2891
...      Pedantic Dev playing White: 444 - 262 - 740  [0.563] 1446
...      Pedantic Dev playing Black: 287 - 368 - 790  [0.472] 1445
...      White vs Black: 812 - 549 - 1530  [0.545] 2891
Elo difference: 12.1 +/- 8.7, LOS: 99.7 %, DrawRatio: 52.9 %
SPRT: llr 2.97 (100.7%), lbound -2.94, ubound 2.94 - H1 was accepted
info string depth 15 time 7.4400 nodes 12499822 nps 1680083.6022