### PR TITLE
Change default contempt from 0 to -25. +4 elo

### DIFF
--- a/Pedantic/Chess/BasicSearch.cs
+++ b/Pedantic/Chess/BasicSearch.cs
@@ -125,7 +125,15 @@ namespace Pedantic.Chess
         public int DrawScore
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => (int)(8 - (NodesVisited & 0x7) + UciOptions.Contempt);
+            get
+            {
+                int score = (int)(8 - (NodesVisited & 0x7));
+                if (board.GamePhase < GamePhase.EndGame)
+                {
+                    score += rootSideToMove == board.SideToMove ? UciOptions.Contempt : -UciOptions.Contempt;
+                }
+                return score;
+            }
         }
 
         #endregion
@@ -134,6 +142,7 @@ namespace Pedantic.Chess
 
         public void Search()
         {
+            rootSideToMove = board.SideToMove;
             string position = board.ToFenString();
             MoveList list = listPool.Rent();
 
@@ -1038,6 +1047,7 @@ namespace Pedantic.Chess
         private DateTime startDateTime = DateTime.MinValue;
         private int rootChanges = 0;
         private long tbHits = 0;
+        private Color rootSideToMove = Color.None;
         internal static readonly int[] AspWindow = [33, 100, 300, 900, 2700, INFINITE_WINDOW];
         internal static readonly sbyte[] NMP = new sbyte[MAX_PLY];
         internal static readonly sbyte[] LMP = new sbyte[LMP_MAX_DEPTH_CUTOFF];

--- a/Pedantic/Chess/UciOptions.cs
+++ b/Pedantic/Chess/UciOptions.cs
@@ -627,7 +627,7 @@ namespace Pedantic.Chess
         // UCI Options
         private static UciOptionButton clearHash = new UciOptionButton(OPT_CLEAR_HASH);
         private static UciOptionString engineAbout = new UciOptionString(OPT_ENGINE_ABOUT, $"{APP_NAME_VER} by {APP_AUTHOR}, see {PROGRAM_URL}");
-        private static UciOptionSpin contempt = new UciOptionSpin(OPT_CONTEMPT, 0, -50, 50);
+        private static UciOptionSpin contempt = new UciOptionSpin(OPT_CONTEMPT, -25, -50, 50);
         private static UciOptionString evalFile = new UciOptionString(OPT_EVAL_FILE, "./Pedantic.hce");
         private static UciOptionSpin hashTableSize = new UciOptionSpin(OPT_HASH_TABLE_SIZE, 64, 16, 2048);
         private static UciOptionSpin moveOverhead = new UciOptionSpin(OPT_MOVE_OVERHEAD, 25, 0, 1000);


### PR DESCRIPTION
Score of Pedantic Dev vs Pedantic Base: 2966 - 2848 - 5963  [0.505] 11777
...      Pedantic Dev playing White: 1757 - 1150 - 2982  [0.552] 5889
...      Pedantic Dev playing Black: 1209 - 1698 - 2981  [0.458] 5888
...      White vs Black: 3455 - 2359 - 5963  [0.547] 11777
Elo difference: 3.5 +/- 4.4, LOS: 93.9 %, DrawRatio: 50.6 %
SPRT: llr 2.95 (100.1%), lbound -2.94, ubound 2.94 - H1 was accepted
info string depth 15 time 6.0520 nodes 11881119 nps 1963172.3397