### PR TITLE
Reduce killers and counter moves. +6 elo

### DIFF
--- a/Pedantic/Chess/BasicSearch.cs
+++ b/Pedantic/Chess/BasicSearch.cs
@@ -580,12 +580,12 @@ namespace Pedantic.Chess
                 ssItem.IsCheckingMove = checkingMove;
                 ssItem.Continuation = history.GetContinuation(genMove.Move);
                 
-                bool interesting = inCheck || (genMove.MovePhase < MoveGenPhase.BadCapture) || expandedNodes == 1;
+                bool interesting = inCheck || (genMove.MovePhase < MoveGenPhase.Killers) || expandedNodes == 1;
 
                 int R = 0;
                 if (!interesting)
                 {
-                    if (canPrune && bestScore > MAX_TABLEBASE_LOSS)
+                    if (canPrune && genMove.MovePhase >= MoveGenPhase.BadCapture && bestScore > MAX_TABLEBASE_LOSS)
                     { 
                         // futility pruning
                         if (depth <= UciOptions.FutMaxDepth && !genMove.Move.IsPawnMove && 
@@ -627,6 +627,7 @@ namespace Pedantic.Chess
                         R -= checkingMove ? 1 : 0;
                         R -= isPv ? 1 : 0;
                         R -= hist / UciOptions.LmrHistoryDiv;
+                        R -= genMove.MovePhase == MoveGenPhase.Killers || genMove.MovePhase == MoveGenPhase.Counter ? 1 : 0;
                         R = Math.Clamp(R, 0, depth - 1);
                     }
                 }


### PR DESCRIPTION
Score of Pedantic Dev vs Pedantic Base: 2173 - 2033 - 4071  [0.508] 8277
...      Pedantic Dev playing White: 1292 - 796 - 2051  [0.560] 4139
...      Pedantic Dev playing Black: 881 - 1237 - 2020  [0.457] 4138
...      White vs Black: 2529 - 1677 - 4071  [0.551] 8277
Elo difference: 5.9 +/- 5.3, LOS: 98.5 %, DrawRatio: 49.2 %
SPRT: llr 2.95 (100.3%), lbound -2.94, ubound 2.94 - H1 was accepted
info string depth 15 time 6.2090 nodes 11860790 nps 1910257.6904