### PR TITLE
Estimate hashful to relieve threading access pressure on generation/used. +4 elo

### DIFF
--- a/Pedantic/Chess/BasicSearch.cs
+++ b/Pedantic/Chess/BasicSearch.cs
@@ -257,8 +257,6 @@ namespace Pedantic.Chess
 
                 }
                 Uci.Usage(cpuStats.CpuLoad);
-                Uci.Debug("Incrementing hash table version.");
-                ttCache.IncrementGeneration();
                 Uci.BestMove(bestMove, CanPonder ? ponderMove : Move.NullMove);
             }
             catch (Exception ex)
@@ -315,7 +313,7 @@ namespace Pedantic.Chess
                 if (startReporting || (DateTime.Now - startDateTime).TotalMilliseconds >= 1000)
                 {
                     startReporting = true;
-                    Uci.CurrentMove(depth, move, expandedNodes, NodesVisited, ttCache.Usage);
+                    Uci.CurrentMove(depth, move, expandedNodes, NodesVisited);
                 }
 
                 bool checkingMove = board.IsChecked();
@@ -886,7 +884,7 @@ namespace Pedantic.Chess
         {
             if (Depth >= UciOptions.AspMinDepth)
             {
-                Uci.Info(Depth, SelDepth, ScaleCpScore(score), NodesVisited, clock.Elapsed, PV, ttCache.Usage, tbHits, bound);
+                Uci.Info(Depth, SelDepth, ScaleCpScore(score), NodesVisited, clock.Elapsed, PV, 0, tbHits, bound);
             }
             if (bound == Bound.Lower)
             {

--- a/Pedantic/Chess/Engine.cs
+++ b/Pedantic/Chess/Engine.cs
@@ -52,6 +52,13 @@ namespace Pedantic.Chess
             threads.Wait();     
         }
 
+        public static void StopSearch()
+        {
+            Stop();
+            Uci.Default.Debug("Incrementing hash table version.");
+            TtCache.Default.IncrementGeneration();
+        }
+
         public static void Quit()
         {
             Stop();

--- a/Pedantic/Chess/SearchThread.cs
+++ b/Pedantic/Chess/SearchThread.cs
@@ -53,6 +53,11 @@ namespace Pedantic.Chess
             stack.Initialize(board, history);
             search?.Search();
             done.Signal();
+
+            if (IsPrimary)
+            {
+                Engine.StopSearch();
+            }
         }
 
         public long TotalNodes => search?.NodesVisited ?? 0;

--- a/Pedantic/Chess/Uci.cs
+++ b/Pedantic/Chess/Uci.cs
@@ -49,7 +49,7 @@ namespace Pedantic.Chess
         }
 
         public void Info(int depth, int seldepth, int score, long nodes, long timeMs, IList<Move> pv,
-            int hashfull, long tbHits, Bound bound = Bound.Exact)
+            int hashfull = 0, long tbHits = 0L, Bound bound = Bound.Exact)
         {
             if (!enable)
             {
@@ -67,11 +67,19 @@ namespace Pedantic.Chess
             {
                 sb.Append(" lowerbound");
             }
-            sb.Append($" nodes {nodes} hashfull {hashfull} nps {nps} time {timeMs}");
+
+            sb.Append($" nodes {nodes} nps {nps} time {timeMs}");
+
+            if (hashfull > 0)
+            {
+                sb.Append($" hashfull {hashfull}");
+            }
+
             if (tbHits > 0)
             {
                 sb.Append($" tbhits {tbHits}");
             }
+
             if (bound == Bound.Exact && pv.Count > 0)
             {
                 sb.Append(" pv");
@@ -80,13 +88,14 @@ namespace Pedantic.Chess
                     sb.Append($" {pv[n]}");
                 }
             }
+
             string output = sb.ToString();
             Console.Out.WriteLineAsync(output);
             Util.WriteLine(output);
         }
 
         public void InfoMate(int depth, int seldepth, int mateIn, long nodes, long timeMs,
-            IList<Move> pv, int hashfull, long tbHits)
+            IList<Move> pv, int hashfull = 0, long tbHits = 0L)
         {
             if (!enable)
             {
@@ -94,28 +103,36 @@ namespace Pedantic.Chess
             }
             ValueStringBuilder sb = new(stackalloc char[256]);
             int nps = (int)(nodes * 1000 / Math.Max(1, timeMs));
-            sb.Append($"info depth {depth} seldepth {seldepth} score mate {mateIn} nodes {nodes} hashfull {hashfull} nps {nps} time {timeMs}");
+            sb.Append($"info depth {depth} seldepth {seldepth} score mate {mateIn} nodes {nodes} nps {nps} time {timeMs}");
+
+            if (hashfull > 0)
+            {
+                sb.Append($" hashfull {hashfull}");
+            }
+
             if (tbHits > 0)
             {
                 sb.Append($" tbhits {tbHits}");
             }
+
             sb.Append(" pv");
             for (int n = 0; n < pv.Count; n++)
             {
                 sb.Append($" {pv[n]}");
             }
+
             string output = sb.ToString();
             Console.Out.WriteLineAsync(output);
             Util.WriteLine(output);
         }
 
-        public void CurrentMove(int depth, Move move, int moveNumber, long nodes, int hashfull)
+        public void CurrentMove(int depth, Move move, int moveNumber, long nodes)
         {
             if (!enable)
             {
                 return;
             }
-            string output = $"info depth {depth} currmove {move} currmovenumber {moveNumber} nodes {nodes} hashfull {hashfull}";
+            string output = $"info depth {depth} currmove {move} currmovenumber {moveNumber} nodes {nodes}";
             Console.Out.WriteLineAsync(output);
             Util.WriteLine(output);
         }
@@ -155,6 +172,12 @@ namespace Pedantic.Chess
                 return;
             }
             Console.Out.WriteLineAsync($"info cpuload {cpuload}");
+        }
+
+        public bool Enabled
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => enable;
         }
 
         public static Uci Default => defaultUci;

--- a/Pedantic/Chess/UciOptions.cs
+++ b/Pedantic/Chess/UciOptions.cs
@@ -629,7 +629,7 @@ namespace Pedantic.Chess
         private static UciOptionString engineAbout = new UciOptionString(OPT_ENGINE_ABOUT, $"{APP_NAME_VER} by {APP_AUTHOR}, see {PROGRAM_URL}");
         private static UciOptionSpin contempt = new UciOptionSpin(OPT_CONTEMPT, -25, -50, 50);
         private static UciOptionString evalFile = new UciOptionString(OPT_EVAL_FILE, "./Pedantic.hce");
-        private static UciOptionSpin hashTableSize = new UciOptionSpin(OPT_HASH_TABLE_SIZE, 64, 16, 2048);
+        private static UciOptionSpin hashTableSize = new UciOptionSpin(OPT_HASH_TABLE_SIZE, 64, 16, 1024);
         private static UciOptionSpin moveOverhead = new UciOptionSpin(OPT_MOVE_OVERHEAD, 25, 0, 1000);
         private static UciOptionCheck ponder = new UciOptionCheck(OPT_PONDER, false);
         private static UciOptionCheck randomSearch = new UciOptionCheck(OPT_RANDOM_SEARCH, false);


### PR DESCRIPTION
Score of Pedantic Dev vs Pedantic Base: 2050 - 1961 - 4206  [0.505] 8217
...      Pedantic Dev playing White: 1221 - 811 - 2077  [0.550] 4109
...      Pedantic Dev playing Black: 829 - 1150 - 2129  [0.461] 4108
...      White vs Black: 2371 - 1640 - 4206  [0.544] 8217
Elo difference: 3.8 +/- 5.2, LOS: 92.0 %, DrawRatio: 51.2 %
SPRT: llr 2.97 (101.0%), lbound -2.94, ubound 2.94 - H1 was accepted
info string depth 15 time 5.6670 nodes 10332875 nps 1823341.2740