### PR TITLE
Remove !inCheck from guard. +4 elo

### DIFF
--- a/Pedantic/Chess/BasicSearch.cs
+++ b/Pedantic/Chess/BasicSearch.cs
@@ -546,7 +546,7 @@ namespace Pedantic.Chess
             }
 
             // IIR 
-            if (ttMove.IsNull && !inCheck && depth >= UciOptions.IirMinDepth)
+            if (ttMove.IsNull && depth >= UciOptions.IirMinDepth)
             {
                 depth--;
             }


### PR DESCRIPTION
Score of Pedantic Dev vs Pedantic Base: 3757 - 3590 - 7114  [0.506] 14461
...      Pedantic Dev playing White: 2143 - 1488 - 3600  [0.545] 7231
...      Pedantic Dev playing Black: 1614 - 2102 - 3514  [0.466] 7230
...      White vs Black: 4245 - 3102 - 7114  [0.540] 14461
Elo difference: 4.0 +/- 4.0, LOS: 97.4 %, DrawRatio: 49.2 %
SPRT: llr 2.96 (100.6%), lbound -2.94, ubound 2.94 - H1 was accepted
info string depth 15 time 6.2160 nodes 11659226 nps 1875679.8584