### PR TITLE
Increase lmr if opponent has less than two pieces on board. +4 elo

### DIFF
--- a/Pedantic/Chess/BasicSearch.cs
+++ b/Pedantic/Chess/BasicSearch.cs
@@ -622,6 +622,7 @@ namespace Pedantic.Chess
                     {
                         R = LMR[Math.Min(depth, MAX_PLY - 1), Math.Min(expandedNodes - 1, LMR_MAX_MOVES - 1)];
                         R += !improving ? 1 : 0;
+                        R += board.PieceCount(board.SideToMove.Flip()) <= 2 ? 1 : 0;
                         R -= checkingMove ? 1 : 0;
                         R -= isPv ? 1 : 0;
                         R -= hist / UciOptions.LmrHistoryDiv;


### PR DESCRIPTION
Score of Pedantic Dev vs Pedantic Base: 4202 - 4028 - 7997  [0.505] 16227
...      Pedantic Dev playing White: 2466 - 1663 - 3984  [0.549] 8113
...      Pedantic Dev playing Black: 1736 - 2365 - 4013  [0.461] 8114
...      White vs Black: 4831 - 3399 - 7997  [0.544] 16227
Elo difference: 3.7 +/- 3.8, LOS: 97.2 %, DrawRatio: 49.3 %
SPRT: llr 2.95 (100.2%), lbound -2.94, ubound 2.94 - H1 was accepted
info string depth 15 time 5.9390 nodes 11619237 nps 1956429.8703