### PR TITLE
Disable CET

### DIFF
--- a/Pedantic/Pedantic.csproj
+++ b/Pedantic/Pedantic.csproj
@@ -12,6 +12,7 @@
     <AnalysisLevel>latest</AnalysisLevel>
     <Configurations>Debug;Release;Profiling</Configurations>
     <PublishTrimmed>True</PublishTrimmed>
+    <CETCompat>false</CETCompat>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
Hi JoAnn,

CET compatibility was [enabled by default](https://learn.microsoft.com/en-us/dotnet/core/compatibility/interop/9.0/cet-support) in .NET 9.

This caused a performance regression in Lynx (see https://github.com/lynx-chess/Lynx/pull/1112, https://github.com/lynx-chess/Lynx/pull/1108), until I manually disabled it.

Could you test this change to see if that's also your case?